### PR TITLE
Skip calculating the md5 hash for local files when last modified timestamp matches

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -10,6 +10,7 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 ** Added
 
    - ~-d~, ~--debug~ flag for log messages
+   - ~-l~, ~--last-modified~ flag to use last modified stamp
 
 ** Changed
 

--- a/README.org
+++ b/README.org
@@ -19,12 +19,22 @@ hash of the file contents.
       -s, --source <value>  Source directory to sync to S3
       -b, --bucket <value>  S3 bucket name
       -p, --prefix <value>  Prefix within the S3 Bucket
+      -l, --last-modified   Ignore local files where last modified matches
       -i, --include <value> Include matching paths
       -x, --exclude <value> Exclude matching paths
       -d, --debug           Enable debug logging
   #+end_example
 
 The ~--include~ and ~--exclude~ parameters can be used more than once.
+
+** ~l~, ~-last-modified~
+
+Where the last modified time stamp for a local file matches the remote
+key, the files will be treated as the same. An MD5 hash for the local
+file will not be created, which could be expensive if the source
+directory is across a network and the files are large.
+
+For files on a local disk this flag shouldn't be needed.
 
 * Behaviour
 

--- a/README.org
+++ b/README.org
@@ -51,6 +51,19 @@ When considering a local file, the following table governs what should happen:
 | 6 | is missing | exists     | -                | -                  | delete              |
 |---+------------+------------+------------------+--------------------+---------------------|
 
+When the ~last-modified~ flag is set, then the following table is
+used:
+
+|----+------------+------------+---------------+--------------------+---------------------|
+|  # | local file | remote key | last-modified | hash of other keys | action              |
+|----+------------+------------+---------------+--------------------+---------------------|
+| 1a | exists     | exists     | matches       | -                  | do nothing          |
+| 1b | exists     | exists     | no-match      | -                  | see original table  |
+|  2 | exists     | is missing |               | matches            | copy from other key |
+|  3 | exists     | is missing |               | no matches         | upload              |
+|  6 | is missing | exists     |               | -                  | delete              |
+|----+------------+------------+---------------+--------------------+---------------------|
+
 * Executable JAR
 
 To build as an executable jar, perform `sbt assembly`

--- a/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
@@ -35,6 +35,9 @@ object ParseArgs {
         .unbounded()
         .action((str,c) => c.copy(filters = c.filters ++ str.map(Exclude)))
         .text("Exclude matching paths"),
+      opt[Unit]('l', "last-modified")
+        .action((_, c) => c.copy(lastModified = true))
+        .text("Ignore local files where last modified matches"),
       opt[Unit]('d', "debug")
         .action((_, c) => c.copy(debug = true))
         .text("Enable debug logging")

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
@@ -1,7 +1,7 @@
 package net.kemitix.thorp.cli
 
 import net.kemitix.thorp.core.Resource
-import net.kemitix.thorp.domain.Config
+import net.kemitix.thorp.domain.{Bucket, Config, LastModified}
 import org.scalatest.FunSpec
 
 import scala.util.Try
@@ -67,6 +67,33 @@ class ParseArgsTest extends FunSpec {
       val debugFlag = invokeWithDebug("-d")
       it("debug should be true") {
         assert(debugFlag.contains(true))
+      }
+    }
+  }
+
+  describe("parse - last modified") {
+    def invokeWithLastModified(lastModified: String) = {
+      val strings = List("--source", pathTo("."), "--bucket", "bucket", lastModified)
+        .filter(_ != "")
+      ParseArgs(strings, defaultConfig).map(_.lastModified)
+    }
+
+    describe("when no last-modified flag") {
+      val lastModifiedFlag = invokeWithLastModified("")
+      it("last-modified should be false") {
+        assert(lastModifiedFlag.contains(false))
+      }
+    }
+    describe("when long last-modified flag") {
+      val lastModifiedFlag = invokeWithLastModified("--last-modified")
+      it("last-modified should be true") {
+        assert(lastModifiedFlag.contains(true))
+      }
+    }
+    describe("when short last-modified flag") {
+      val lastModifiedFlag = invokeWithLastModified("-l")
+      it("last-modified should be true") {
+        assert(lastModifiedFlag.contains(true))
       }
     }
   }

--- a/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
@@ -1,5 +1,7 @@
 package net.kemitix.thorp.core
 
+import java.time.temporal.ChronoField
+
 import net.kemitix.thorp.core.Action.{DoNothing, ToCopy, ToUpload}
 import net.kemitix.thorp.domain._
 
@@ -8,6 +10,12 @@ object ActionGenerator {
   def createActions(s3MetaData: S3MetaData)
                    (implicit c: Config): Stream[Action] =
     s3MetaData match {
+
+      // last-modified flag is set, local file and remote key both exist, and last modified matches
+      case S3MetaData(localFile, _, Some(RemoteMetaData(remoteKey, _, lastModified)))
+        if c.lastModified &&
+          (lastModified matches localFile.file.lastModified)
+      => doNothing(c.bucket, remoteKey)
 
       // #1 local exists, remote exists, remote matches - do nothing
       case S3MetaData(localFile, _, Some(RemoteMetaData(remoteKey, remoteHash, _)))

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
@@ -9,6 +9,7 @@ final case class Config(
                          multiPartThreshold: Long = 1024 * 1024 * 5,
                          maxRetries: Int = 3,
                          debug: Boolean = false,
+                         lastModified: Boolean = false,
                          source: File
 ) {
   require(source.isDirectory, s"Source must be a directory: $source")

--- a/domain/src/main/scala/net/kemitix/thorp/domain/LastModified.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/LastModified.scala
@@ -1,5 +1,13 @@
 package net.kemitix.thorp.domain
 
 import java.time.Instant
+import java.time.temporal.ChronoField
 
-final case class LastModified(when: Instant)
+final case class LastModified(when: Instant) {
+
+  def matches(epochMilliseconds: Long): Boolean = {
+    val millis = when.getLong(ChronoField.MILLI_OF_SECOND)
+    (when.getEpochSecond * 1000) + millis == epochMilliseconds
+  }
+
+}

--- a/domain/src/test/scala/net/kemitix/s3thorp/domain/LastModifiedTest.scala
+++ b/domain/src/test/scala/net/kemitix/s3thorp/domain/LastModifiedTest.scala
@@ -1,0 +1,32 @@
+package net.kemitix.s3thorp.domain
+
+import java.time.Instant
+import java.time.temporal.ChronoField
+
+import org.scalatest.FunSpec
+
+class LastModifiedTest extends FunSpec {
+
+  describe("match against a file last modified") {
+    val fileLastModified = 1560464353000L
+    describe("when time stamps are identical") {
+      val lastModified = LastModified(Instant.ofEpochMilli(fileLastModified))
+      it("how to get epochMillis from an Instant") {
+        val when = lastModified.when
+        val epochSecond = when.getEpochSecond
+        val millis = when.getLong(ChronoField.MILLI_OF_SECOND)
+        val epochMillis = (epochSecond * 1000) + millis
+        assertResult(fileLastModified)(epochMillis)
+      }
+      it("should match") {
+        assertResult(true)(lastModified.matches(fileLastModified))
+      }
+    }
+    describe("when time stamps are out by 1 millisecond") {
+      val lastModified = LastModified(Instant.ofEpochMilli(fileLastModified + 1))
+      it("should not match") {
+        assertResult(false)(lastModified.matches(fileLastModified))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add an option to skip calculating the md5 hash for local files, where the last modified timestamp matches the timestamp on S3.

Calculating the MD5 hash for a file can be time-expensive for large files or when they are on network storage.

Not enabled by default.