### PR TITLE
Add support for per directory configuration files

### DIFF
--- a/aws-api/src/main/scala/net/kemitix/thorp/aws/api/S3Client.scala
+++ b/aws-api/src/main/scala/net/kemitix/thorp/aws/api/S3Client.scala
@@ -1,13 +1,14 @@
 package net.kemitix.thorp.aws.api
 
+import cats.effect.IO
 import net.kemitix.thorp.aws.api.S3Action.{CopyS3Action, DeleteS3Action}
 import net.kemitix.thorp.domain._
 
-trait S3Client[M[_]] {
+trait S3Client {
 
   def listObjects(bucket: Bucket,
                   prefix: RemoteKey
-                 )(implicit logger: Logger[M]): M[S3ObjectsData]
+                 )(implicit logger: Logger): IO[S3ObjectsData]
 
   def upload(localFile: LocalFile,
              bucket: Bucket,
@@ -15,16 +16,16 @@ trait S3Client[M[_]] {
              multiPartThreshold: Long,
              tryCount: Int,
              maxRetries: Int)
-            (implicit logger: Logger[M]): M[S3Action]
+            (implicit logger: Logger): IO[S3Action]
 
   def copy(bucket: Bucket,
            sourceKey: RemoteKey,
            hash: MD5Hash,
            targetKey: RemoteKey
-          )(implicit logger: Logger[M]): M[CopyS3Action]
+          )(implicit logger: Logger): IO[CopyS3Action]
 
   def delete(bucket: Bucket,
              remoteKey: RemoteKey
-            )(implicit logger: Logger[M]): M[DeleteS3Action]
+            )(implicit logger: Logger): IO[DeleteS3Action]
 
 }

--- a/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientBuilder.scala
+++ b/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientBuilder.scala
@@ -1,17 +1,16 @@
 package net.kemitix.thorp.aws.lib
 
-import cats.Monad
 import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import net.kemitix.thorp.aws.api.S3Client
 
 object S3ClientBuilder {
 
-  def createClient[M[_]: Monad](amazonS3Client: AmazonS3,
-                   amazonS3TransferManager: TransferManager): S3Client[M] =
+  def createClient(amazonS3Client: AmazonS3,
+                   amazonS3TransferManager: TransferManager): S3Client =
     new ThorpS3Client(amazonS3Client, amazonS3TransferManager)
 
-  def defaultClient[M[_]: Monad]: S3Client[M] =
+  def defaultClient: S3Client =
     createClient(AmazonS3ClientBuilder.defaultClient, TransferManagerBuilder.defaultTransferManager)
 
 }

--- a/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientCopier.scala
+++ b/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientCopier.scala
@@ -1,24 +1,23 @@
 package net.kemitix.thorp.aws.lib
 
-import cats.Monad
-import cats.implicits._
+import cats.effect.IO
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.CopyObjectRequest
 import net.kemitix.thorp.aws.api.S3Action.CopyS3Action
 import net.kemitix.thorp.aws.lib.S3ClientLogging.{logCopyFinish, logCopyStart}
 import net.kemitix.thorp.domain.{Bucket, Logger, MD5Hash, RemoteKey}
 
-class S3ClientCopier[M[_]: Monad](amazonS3: AmazonS3) {
+class S3ClientCopier(amazonS3: AmazonS3) {
 
   def copy(bucket: Bucket,
            sourceKey: RemoteKey,
            hash: MD5Hash,
            targetKey: RemoteKey)
-          (implicit logger: Logger[M]): M[CopyS3Action] =
+          (implicit logger: Logger): IO[CopyS3Action] =
   for {
-    _ <- logCopyStart[M](bucket, sourceKey, targetKey)
+    _ <- logCopyStart(bucket, sourceKey, targetKey)
     _ <- copyObject(bucket, sourceKey, hash, targetKey)
-    _ <- logCopyFinish[M](bucket, sourceKey,targetKey)
+    _ <- logCopyFinish(bucket, sourceKey,targetKey)
   } yield CopyS3Action(targetKey)
 
   private def copyObject(bucket: Bucket,
@@ -28,7 +27,7 @@ class S3ClientCopier[M[_]: Monad](amazonS3: AmazonS3) {
     val request =
       new CopyObjectRequest(bucket.name, sourceKey.key, bucket.name, targetKey.key)
         .withMatchingETagConstraint(hash.hash)
-    Monad[M].pure(amazonS3.copyObject(request))
+    IO(amazonS3.copyObject(request))
   }
 
 }

--- a/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientDeleter.scala
+++ b/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientDeleter.scala
@@ -1,25 +1,24 @@
 package net.kemitix.thorp.aws.lib
 
-import cats.Monad
-import cats.implicits._
+import cats.effect.IO
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.DeleteObjectRequest
 import net.kemitix.thorp.aws.api.S3Action.DeleteS3Action
 import net.kemitix.thorp.aws.lib.S3ClientLogging.{logDeleteFinish, logDeleteStart}
 import net.kemitix.thorp.domain.{Bucket, Logger, RemoteKey}
 
-class S3ClientDeleter[M[_]: Monad](amazonS3: AmazonS3) {
+class S3ClientDeleter(amazonS3: AmazonS3) {
 
   def delete(bucket: Bucket,
              remoteKey: RemoteKey)
-            (implicit logger: Logger[M]): M[DeleteS3Action] =
+            (implicit logger: Logger): IO[DeleteS3Action] =
     for {
-      _ <- logDeleteStart[M](bucket, remoteKey)
+      _ <- logDeleteStart(bucket, remoteKey)
       _ <- deleteObject(bucket, remoteKey)
-      _ <- logDeleteFinish[M](bucket, remoteKey)
+      _ <- logDeleteFinish(bucket, remoteKey)
     } yield DeleteS3Action(remoteKey)
 
-  private def deleteObject(bucket: Bucket, remoteKey: RemoteKey) = Monad[M].pure {
-    amazonS3.deleteObject(new DeleteObjectRequest(bucket.name, remoteKey.key))
-  }
+  private def deleteObject(bucket: Bucket, remoteKey: RemoteKey) =
+    IO(amazonS3.deleteObject(new DeleteObjectRequest(bucket.name, remoteKey.key)))
+
 }

--- a/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientLogging.scala
+++ b/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/S3ClientLogging.scala
@@ -1,40 +1,40 @@
 package net.kemitix.thorp.aws.lib
 
-import cats.Monad
+import cats.effect.IO
 import net.kemitix.thorp.domain.{Bucket, Logger, RemoteKey}
 
 object S3ClientLogging {
 
-  def logListObjectsStart[M[_]: Monad](bucket: Bucket,
+  def logListObjectsStart(bucket: Bucket,
                           prefix: RemoteKey)
-                         (implicit logger: Logger[M]): M[Unit] =
+                         (implicit logger: Logger): IO[Unit] =
     logger.info(s"Fetch S3 Summary: ${bucket.name}:${prefix.key}")
 
-  def logListObjectsFinish[M[_]: Monad](bucket: Bucket,
+  def logListObjectsFinish(bucket: Bucket,
                            prefix: RemoteKey)
-                          (implicit logger: Logger[M]): M[Unit] =
+                          (implicit logger: Logger): IO[Unit] =
     logger.info(s"Fetched S3 Summary: ${bucket.name}:${prefix.key}")
 
-  def logCopyStart[M[_]: Monad](bucket: Bucket,
-                                sourceKey: RemoteKey,
-                                targetKey: RemoteKey)
-                               (implicit logger: Logger[M]): M[Unit] =
+  def logCopyStart(bucket: Bucket,
+                   sourceKey: RemoteKey,
+                   targetKey: RemoteKey)
+                  (implicit logger: Logger): IO[Unit] =
     logger.info(s"Copy: ${bucket.name}:${sourceKey.key} => ${targetKey.key}")
 
-  def logCopyFinish[M[_]: Monad](bucket: Bucket,
+  def logCopyFinish(bucket: Bucket,
                     sourceKey: RemoteKey,
                     targetKey: RemoteKey)
-                   (implicit logger: Logger[M]): M[Unit] =
+                   (implicit logger: Logger): IO[Unit] =
     logger.info(s"Copied: ${bucket.name}:${sourceKey.key} => ${targetKey.key}")
 
-  def logDeleteStart[M[_]: Monad](bucket: Bucket,
+  def logDeleteStart(bucket: Bucket,
                      remoteKey: RemoteKey)
-                    (implicit logger: Logger[M]): M[Unit] =
+                    (implicit logger: Logger): IO[Unit] =
       logger.info(s"Delete: ${bucket.name}:${remoteKey.key}")
 
-  def logDeleteFinish[M[_]: Monad](bucket: Bucket,
+  def logDeleteFinish(bucket: Bucket,
                       remoteKey: RemoteKey)
-                     (implicit logger: Logger[M]): M[Unit] =
+                     (implicit logger: Logger): IO[Unit] =
       logger.info(s"Deleted: ${bucket.name}:${remoteKey.key}")
 
 }

--- a/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/UploaderLogging.scala
+++ b/aws-lib/src/main/scala/net/kemitix/thorp/aws/lib/UploaderLogging.scala
@@ -1,22 +1,22 @@
 package net.kemitix.thorp.aws.lib
 
-import cats.Monad
+import cats.effect.IO
 import net.kemitix.thorp.domain.SizeTranslation.sizeInEnglish
 import net.kemitix.thorp.domain.Terminal.clearLine
 import net.kemitix.thorp.domain.{LocalFile, Logger}
 
 object UploaderLogging {
 
-  def logMultiPartUploadStart[M[_]: Monad](localFile: LocalFile,
+  def logMultiPartUploadStart(localFile: LocalFile,
                               tryCount: Int)
-                             (implicit logger: Logger[M]): M[Unit] = {
+                             (implicit logger: Logger): IO[Unit] = {
       val tryMessage = if (tryCount == 1) "" else s"try $tryCount"
       val size = sizeInEnglish(localFile.file.length)
       logger.info(s"${clearLine}upload:$tryMessage:$size:${localFile.remoteKey.key}")
     }
 
-  def logMultiPartUploadFinished[M[_]: Monad](localFile: LocalFile)
-                                (implicit logger: Logger[M]): M[Unit] =
+  def logMultiPartUploadFinished(localFile: LocalFile)
+                                (implicit logger: Logger): IO[Unit] =
     logger.debug(s"upload:finished: ${localFile.remoteKey.key}")
 
 }

--- a/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/DummyLogger.scala
+++ b/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/DummyLogger.scala
@@ -1,18 +1,18 @@
 package net.kemitix.thorp.aws.lib
 
-import cats.Monad
+import cats.effect.IO
 import net.kemitix.thorp.domain.Logger
 
-class DummyLogger[M[_]: Monad] extends Logger[M] {
+class DummyLogger extends Logger {
 
-  override def debug(message: => String): M[Unit] = Monad[M].unit
+  override def debug(message: => String): IO[Unit] = IO.unit
 
-  override def info(message: =>String): M[Unit] = Monad[M].unit
+  override def info(message: =>String): IO[Unit] = IO.unit
 
-  override def warn(message: String): M[Unit] = Monad[M].unit
+  override def warn(message: String): IO[Unit] = IO.unit
 
-  override def error(message: String): M[Unit] = Monad[M].unit
+  override def error(message: String): IO[Unit] = IO.unit
 
-  override def withDebug(debug: Boolean): Logger[M] = this
+  override def withDebug(debug: Boolean): Logger = this
 
 }

--- a/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/DummyLogger.scala
+++ b/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/DummyLogger.scala
@@ -13,4 +13,6 @@ class DummyLogger[M[_]: Monad] extends Logger[M] {
 
   override def error(message: String): M[Unit] = Monad[M].unit
 
+  override def withDebug(debug: Boolean): Logger[M] = this
+
 }

--- a/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/S3ClientSuite.scala
+++ b/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/S3ClientSuite.scala
@@ -2,7 +2,6 @@ package net.kemitix.thorp.aws.lib
 
 import java.time.Instant
 
-import cats.Id
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.services.s3.transfer.model.UploadResult
@@ -23,7 +22,7 @@ class S3ClientSuite
 
   private val prefix = RemoteKey("prefix")
   implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
-  implicit private val implLogger: Logger[Id] = new DummyLogger[Id]
+  implicit private val implLogger: Logger = new DummyLogger
   private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
 
   describe("getS3Status") {
@@ -43,7 +42,7 @@ class S3ClientSuite
         keyotherkey.remoteKey -> HashModified(hash, lastModified),
         keydiffhash.remoteKey -> HashModified(diffhash, lastModified)))
 
-    def invoke(self: S3Client[Id], localFile: LocalFile) = {
+    def invoke(self: S3Client, localFile: LocalFile) = {
       S3MetaDataEnricher.getS3Status(localFile, s3ObjectsData)
     }
 

--- a/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/UploaderSuite.scala
+++ b/aws-lib/src/test/scala/net/kemitix/thorp/aws/lib/UploaderSuite.scala
@@ -2,7 +2,6 @@ package net.kemitix.thorp.aws.lib
 
 import java.time.Instant
 
-import cats.Id
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.transfer._
 import net.kemitix.thorp.aws.api.S3Action.UploadS3Action
@@ -20,7 +19,7 @@ class UploaderSuite
   private val source = Resource(this, ".")
   private val prefix = RemoteKey("prefix")
   implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
-  implicit private val implLogger: Logger[Id] = new DummyLogger[Id]
+  implicit private val implLogger: Logger = new DummyLogger
   private val fileToKey = generateKey(config.source, config.prefix) _
   val lastModified = LastModified(Instant.now())
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val `aws-lib` = (project in file("aws-lib"))
 lazy val core = (project in file("core"))
   .settings(commonSettings)
   .settings(assemblyJarName in assembly := "core.jar")
+  .settings(catsEffectsSettings)
   .settings(testDependencies)
   .dependsOn(`aws-api`)
 

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,9 @@ val catsEffectsSettings = Seq(
 
 // cli -> thorp-lib -> aws-lib -> core -> aws-api -> domain
 
+lazy val root = (project in file("."))
+  .settings(commonSettings)
+
 lazy val cli = (project in file("cli"))
   .settings(commonSettings)
   .settings(mainClass in assembly := Some("net.kemitix.thorp.cli.Main"))

--- a/build.sbt
+++ b/build.sbt
@@ -27,19 +27,6 @@ val awsSdkDependencies = Seq(
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.9"
   )
 )
-val catsSettings = Seq (
-  libraryDependencies ++=  Seq(
-    "org.typelevel" %% "cats-core" % "1.6.1"
-  ),
-  // recommended for cats-effects
-  scalacOptions ++= Seq(
-    "-feature",
-    "-deprecation",
-    "-unchecked",
-    "-language:postfixOps",
-    "-language:higherKinds",
-    "-Ypartial-unification")
-)
 val catsEffectsSettings = Seq(
   libraryDependencies ++=  Seq(
     "org.typelevel" %% "cats-effect" % "1.3.1"
@@ -63,7 +50,6 @@ lazy val cli = (project in file("cli"))
   .settings(commonSettings)
   .settings(mainClass in assembly := Some("net.kemitix.thorp.cli.Main"))
   .settings(applicationSettings)
-  .settings(catsEffectsSettings)
   .aggregate(`thorp-lib`, `aws-lib`, core, `aws-api`, domain)
   .settings(commandLineParsing)
   .settings(testDependencies)
@@ -84,17 +70,16 @@ lazy val `aws-lib` = (project in file("aws-lib"))
 lazy val core = (project in file("core"))
   .settings(commonSettings)
   .settings(assemblyJarName in assembly := "core.jar")
-  .settings(catsEffectsSettings)
   .settings(testDependencies)
   .dependsOn(`aws-api`)
 
 lazy val `aws-api` = (project in file("aws-api"))
   .settings(commonSettings)
   .settings(assemblyJarName in assembly := "aws-api.jar")
-  .settings(catsSettings)
   .dependsOn(domain)
 
 lazy val domain = (project in file("domain"))
   .settings(commonSettings)
   .settings(assemblyJarName in assembly := "domain.jar")
+  .settings(catsEffectsSettings)
   .settings(testDependencies)

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Main.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Main.scala
@@ -1,17 +1,14 @@
 package net.kemitix.thorp.cli
 
-import java.nio.file.Paths
-
 import cats.effect.ExitCase.{Canceled, Completed, Error}
 import cats.effect.{ExitCode, IO, IOApp}
-import net.kemitix.thorp.domain.Config
 
 object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val exitCaseLogger = new PrintLogger[IO](false)
+    val exitCaseLogger = new PrintLogger(false)
     ParseArgs(args)
-      .map(Program[IO])
+      .map(Program(_))
       .getOrElse(IO(ExitCode.Error))
       .guaranteeCase {
           case Canceled => exitCaseLogger.warn("Interrupted")

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Main.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Main.scala
@@ -8,12 +8,9 @@ import net.kemitix.thorp.domain.Config
 
 object Main extends IOApp {
 
-  val defaultConfig: Config =
-    Config(source = Paths.get(".").toFile)
-
   override def run(args: List[String]): IO[ExitCode] = {
     val exitCaseLogger = new PrintLogger[IO](false)
-    ParseArgs(args, defaultConfig)
+    ParseArgs(args)
       .map(Program[IO])
       .getOrElse(IO(ExitCode.Error))
       .guaranteeCase {

--- a/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
@@ -3,45 +3,41 @@ package net.kemitix.thorp.cli
 import java.io.File
 import java.nio.file.Paths
 
-import net.kemitix.thorp.domain.Filter.{Exclude, Include}
-import net.kemitix.thorp.domain.{Bucket, Config, RemoteKey}
+import net.kemitix.thorp.core.ConfigOption
 import scopt.OParser
 
 object ParseArgs {
 
-  val configParser: OParser[Unit, Config] = {
-    val parserBuilder = OParser.builder[Config]
+  val configParser: OParser[Unit, List[ConfigOption]] = {
+    val parserBuilder = OParser.builder[List[ConfigOption]]
     import parserBuilder._
     OParser.sequence(
       programName("thorp"),
       head("thorp"),
       opt[String]('s', "source")
-        .action((str, c) => c.copy(source = Paths.get(str).toFile))
-        .validate(s => if (new File(s).isDirectory) Right(()) else Left("Source is not a directory"))
-        .required()
-        .text("Source directory to sync to S3"),
+        .action((str, cos) => ConfigOption.Source(Paths.get(str)) :: cos)
+        .text("Source directory to sync to destination"),
       opt[String]('b', "bucket")
-        .action((str, c) => c.copy(bucket = Bucket(str)))
-        .required()
+        .action((str, cos) => ConfigOption.Bucket(str) :: cos)
         .text("S3 bucket name"),
       opt[String]('p', "prefix")
-        .action((str, c) => c.copy(prefix = RemoteKey(str)))
+        .action((str, cos) => ConfigOption.Prefix(str) :: cos)
         .text("Prefix within the S3 Bucket"),
-      opt[Seq[String]]('i', "include")
+      opt[String]('i', "include")
         .unbounded()
-        .action((str, c) => c.copy(filters = c.filters ++ str.map(Include)))
+        .action((str, cos) => ConfigOption.Include(str) :: cos)
         .text("Include only matching paths"),
-      opt[Seq[String]]('x', "exclude")
+      opt[String]('x', "exclude")
         .unbounded()
-        .action((str,c) => c.copy(filters = c.filters ++ str.map(Exclude)))
+        .action((str,cos) => ConfigOption.Exclude(str) :: cos)
         .text("Exclude matching paths"),
       opt[Unit]('d', "debug")
-        .action((_, c) => c.copy(debug = true))
+        .action((_, cos) => ConfigOption.Debug() :: cos)
         .text("Enable debug logging")
     )
   }
 
-  def apply(args: List[String], defaultConfig: Config): Option[Config] =
-    OParser.parse(configParser, args, defaultConfig)
+  def apply(args: List[String]): Option[List[ConfigOption]] =
+    OParser.parse(configParser, args, List())
 
 }

--- a/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
@@ -1,6 +1,5 @@
 package net.kemitix.thorp.cli
 
-import java.io.File
 import java.nio.file.Paths
 
 import net.kemitix.thorp.core.ConfigOption

--- a/cli/src/main/scala/net/kemitix/thorp/cli/PrintLogger.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/PrintLogger.scala
@@ -15,4 +15,6 @@ class PrintLogger[M[_]: Monad](isDebug: Boolean = false) extends Logger[M] {
 
   override def error(message: String): M[Unit] = Monad[M].pure(println(s"[ ERROR] $message"))
 
+  override def withDebug(debug: Boolean): Logger[M] = if (isDebug == debug) this else new PrintLogger[M](debug)
+
 }

--- a/cli/src/main/scala/net/kemitix/thorp/cli/PrintLogger.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/PrintLogger.scala
@@ -3,7 +3,7 @@ package net.kemitix.thorp.cli
 import cats.Monad
 import net.kemitix.thorp.domain.Logger
 
-class PrintLogger[M[_]: Monad](isDebug: Boolean) extends Logger[M] {
+class PrintLogger[M[_]: Monad](isDebug: Boolean = false) extends Logger[M] {
 
   override def debug(message: => String): M[Unit] =
     if (isDebug) Monad[M].pure(println(s"[ DEBUG] $message"))

--- a/cli/src/main/scala/net/kemitix/thorp/cli/PrintLogger.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/PrintLogger.scala
@@ -1,20 +1,22 @@
 package net.kemitix.thorp.cli
 
-import cats.Monad
+import cats.effect.IO
 import net.kemitix.thorp.domain.Logger
 
-class PrintLogger[M[_]: Monad](isDebug: Boolean = false) extends Logger[M] {
+class PrintLogger(isDebug: Boolean = false) extends Logger {
 
-  override def debug(message: => String): M[Unit] =
-    if (isDebug) Monad[M].pure(println(s"[ DEBUG] $message"))
-    else Monad[M].unit
+  override def debug(message: => String): IO[Unit] =
+    if (isDebug) IO(println(s"[ DEBUG] $message"))
+    else IO.unit
 
-  override def info(message: => String): M[Unit] = Monad[M].pure(println(s"[  INFO] $message"))
+  override def info(message: => String): IO[Unit] = IO(println(s"[  INFO] $message"))
 
-  override def warn(message: String): M[Unit] = Monad[M].pure(println(s"[  WARN] $message"))
+  override def warn(message: String): IO[Unit] = IO(println(s"[  WARN] $message"))
 
-  override def error(message: String): M[Unit] = Monad[M].pure(println(s"[ ERROR] $message"))
+  override def error(message: String): IO[Unit] = IO(println(s"[ ERROR] $message"))
 
-  override def withDebug(debug: Boolean): Logger[M] = if (isDebug == debug) this else new PrintLogger[M](debug)
+  override def withDebug(debug: Boolean): Logger =
+    if (isDebug == debug) this
+    else new PrintLogger(debug)
 
 }

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -23,7 +23,6 @@ object Program {
       case Right(config) =>
         implicit val logger: Logger[M] = new PrintLogger[M](config.debug)
         for {
-          _ <- logger.info("Thorp - hashed sync for cloud storage")
           _ <- Sync.run[M](config, S3ClientBuilder.defaultClient)
         } yield ExitCode.Success
     }

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -4,17 +4,28 @@ import cats.Monad
 import cats.effect.ExitCode
 import cats.implicits._
 import net.kemitix.thorp.aws.lib.S3ClientBuilder
-import net.kemitix.thorp.core.Sync
-import net.kemitix.thorp.domain.{Config, Logger}
+import net.kemitix.thorp.core.{ConfigOption, ConfigValidation, ConfigurationBuilder, Sync}
+import net.kemitix.thorp.domain.Logger
 
 object Program {
 
-  def apply[M[_]: Monad](config: Config): M[ExitCode] = {
-    implicit val logger: Logger[M] = new PrintLogger[M](config.debug)
+  def reportErrors[M[_]: Monad](errors: List[ConfigValidation]): M[ExitCode] = {
+    implicit val logger: Logger[M] = new PrintLogger[M]()
     for {
-      _ <- logger.info("Thorp - hashed sync for cloud storage")
-      _ <- Sync.run[M](config, S3ClientBuilder.defaultClient)
-    } yield ExitCode.Success
+      _ <- logger.error("There were errors:")
+      _ <- Monad[M].pure(errors.map(cv => logger.error(s" - ${cv.errorMessage}")))
+    } yield ExitCode.Error
   }
+
+  def apply[M[_]: Monad](configOptions: Seq[ConfigOption]): M[ExitCode] =
+    ConfigurationBuilder(configOptions) match {
+      case Left(errors) => reportErrors[M](errors.toList)
+      case Right(config) =>
+        implicit val logger: Logger[M] = new PrintLogger[M](config.debug)
+        for {
+          _ <- logger.info("Thorp - hashed sync for cloud storage")
+          _ <- Sync.run[M](config, S3ClientBuilder.defaultClient)
+        } yield ExitCode.Success
+    }
 
 }

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -4,27 +4,23 @@ import cats.Monad
 import cats.effect.ExitCode
 import cats.implicits._
 import net.kemitix.thorp.aws.lib.S3ClientBuilder
-import net.kemitix.thorp.core.{ConfigOption, ConfigValidation, ConfigurationBuilder, Sync}
+import net.kemitix.thorp.core.{ConfigOption, Sync}
 import net.kemitix.thorp.domain.Logger
 
-object Program {
+trait Program {
 
-  def reportErrors[M[_]: Monad](errors: List[ConfigValidation]): M[ExitCode] = {
+  def apply[M[_]: Monad](configOptions: Seq[ConfigOption]): M[ExitCode] = {
     implicit val logger: Logger[M] = new PrintLogger[M]()
-    for {
-      _ <- logger.error("There were errors:")
-      _ <- Monad[M].pure(errors.map(cv => logger.error(s" - ${cv.errorMessage}")))
-    } yield ExitCode.Error
+    Sync[M](S3ClientBuilder.defaultClient[M])(configOptions) flatMap {
+      case Left(errors) =>
+        for {
+          _ <- logger.error(s"There were errors:")
+          _ <- Monad[M].pure(errors.map(error => logger.error(s" - $error")))
+        } yield ExitCode.Error
+      case Right(_) => Monad[M].pure(ExitCode.Success)
+    }
   }
 
-  def apply[M[_]: Monad](configOptions: Seq[ConfigOption]): M[ExitCode] =
-    ConfigurationBuilder(configOptions) match {
-      case Left(errors) => reportErrors[M](errors.toList)
-      case Right(config) =>
-        implicit val logger: Logger[M] = new PrintLogger[M](config.debug)
-        for {
-          _ <- Sync.run[M](config, S3ClientBuilder.defaultClient)
-        } yield ExitCode.Success
-    }
-
 }
+
+object Program extends Program

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
@@ -1,7 +1,7 @@
 package net.kemitix.thorp.cli
 
-import net.kemitix.thorp.core.Resource
-import net.kemitix.thorp.domain.Config
+import net.kemitix.thorp.core.ConfigOption.Debug
+import net.kemitix.thorp.core.{ConfigOption, Resource}
 import org.scalatest.FunSpec
 
 import scala.util.Try
@@ -9,11 +9,10 @@ import scala.util.Try
 class ParseArgsTest extends FunSpec {
 
   val source = Resource(this, "")
-  val defaultConfig: Config = Config(source = source)
 
   describe("parse - source") {
     def invokeWithSource(path: String) =
-      ParseArgs(List("--source", path, "--bucket", "bucket"), defaultConfig)
+      ParseArgs(List("--source", path, "--bucket", "bucket"))
 
     describe("when source is a directory") {
       val result = invokeWithSource(pathTo("."))
@@ -21,52 +20,35 @@ class ParseArgsTest extends FunSpec {
         assert(result.isDefined)
       }
     }
-    describe("when source is a file") {
-      val result = invokeWithSource(pathTo("ParseArgs.class"))
-      it("should fail") {
-        assert(result.isEmpty)
-      }
-    }
-    describe("when source is not found") {
-      val result = invokeWithSource(pathTo("not-found"))
-      it("should fail") {
-        assert(result.isEmpty)
-      }
-    }
     describe("when source is a relative path to a directory") {
       it("should succeed") {pending}
-    }
-    describe("when source is a relative path to a file") {
-      it("should fail") {pending}
-    }
-    describe("when source is a relative path to a missing path") {
-      it("should fail") {pending}
     }
   }
 
   describe("parse - debug") {
-    def invokeWithDebug(debug: String) = {
-      val strings = List("--source", pathTo("."), "--bucket", "bucket", debug)
+    def invokeWithArgument(arg: String): List[ConfigOption] = {
+      val strings = List("--source", pathTo("."), "--bucket", "bucket", arg)
           .filter(_ != "")
-      ParseArgs(strings, defaultConfig).map(_.debug)
+      val maybeOptions = ParseArgs(strings)
+      maybeOptions.getOrElse(List())
     }
 
     describe("when no debug flag") {
-      val debugFlag = invokeWithDebug("")
+      val configOptions = invokeWithArgument("")
       it("debug should be false") {
-        assert(debugFlag.contains(false))
+        assertResult(false)(configOptions.contains(Debug()))
       }
     }
     describe("when long debug flag") {
-      val debugFlag = invokeWithDebug("--debug")
+      val configOptions = invokeWithArgument("--debug")
       it("debug should be true") {
-        assert(debugFlag.contains(true))
+        assert(configOptions.contains(Debug()))
       }
     }
     describe("when short debug flag") {
-      val debugFlag = invokeWithDebug("-d")
+      val configOptions = invokeWithArgument("-d")
       it("debug should be true") {
-        assert(debugFlag.contains(true))
+        assert(configOptions.contains(Debug()))
       }
     }
   }

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
@@ -1,0 +1,14 @@
+package net.kemitix.thorp.core
+
+import java.nio.file.Path
+
+sealed trait ConfigOption
+
+object ConfigOption {
+  case class Source(path: Path) extends ConfigOption
+  case class Bucket(name: String) extends ConfigOption
+  case class Prefix(path: String) extends ConfigOption
+  case class Include(pattern: String) extends ConfigOption
+  case class Exclude(pattern: String) extends ConfigOption
+  case class Debug() extends ConfigOption
+}

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
@@ -2,13 +2,30 @@ package net.kemitix.thorp.core
 
 import java.nio.file.Path
 
-sealed trait ConfigOption
+import net.kemitix.thorp.domain
+import net.kemitix.thorp.domain.{Config, RemoteKey}
+
+sealed trait ConfigOption {
+  def update(config: Config): Config
+}
 
 object ConfigOption {
-  case class Source(path: Path) extends ConfigOption
-  case class Bucket(name: String) extends ConfigOption
-  case class Prefix(path: String) extends ConfigOption
-  case class Include(pattern: String) extends ConfigOption
-  case class Exclude(pattern: String) extends ConfigOption
-  case class Debug() extends ConfigOption
+  case class Source(path: Path) extends ConfigOption {
+    override def update(config: Config): Config = config.copy(source = path.toFile)
+  }
+  case class Bucket(name: String) extends ConfigOption {
+    override def update(config: Config): Config = config.copy(bucket = domain.Bucket(name))
+  }
+  case class Prefix(path: String) extends ConfigOption {
+    override def update(config: Config): Config = config.copy(prefix = RemoteKey(path))
+  }
+  case class Include(pattern: String) extends ConfigOption {
+    override def update(config: Config): Config = config.copy(filters = domain.Filter.Include(pattern) :: config.filters)
+  }
+  case class Exclude(pattern: String) extends ConfigOption {
+    override def update(config: Config): Config = config.copy(filters = domain.Filter.Exclude(pattern) :: config.filters)
+  }
+  case class Debug() extends ConfigOption {
+    override def update(config: Config): Config = config.copy(debug = true)
+  }
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigValidation.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigValidation.scala
@@ -1,0 +1,22 @@
+package net.kemitix.thorp.core
+
+sealed trait ConfigValidation {
+
+  def errorMessage: String
+}
+
+object ConfigValidation {
+
+  case object SourceIsNotADirectory extends ConfigValidation {
+    override def errorMessage: String = "Source must be a directory"
+  }
+
+  case object SourceIsNotReadable extends ConfigValidation {
+    override def errorMessage: String = "Source must be readable"
+  }
+
+  case object BucketNameIsMissing extends ConfigValidation {
+    override def errorMessage: String = "Bucket name is missing"
+  }
+
+}

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
@@ -1,0 +1,35 @@
+package net.kemitix.thorp.core
+
+import java.io.File
+
+import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import cats.implicits._
+import net.kemitix.thorp.domain.{Bucket, Config}
+
+sealed trait ConfigValidator {
+
+  type ValidationResult[A] = ValidatedNec[ConfigValidation, A]
+
+  def validateSourceIsDirectory(source: File): ValidationResult[File] =
+    if(source.isDirectory) source.validNec
+    else ConfigValidation.SourceIsNotADirectory.invalidNec
+
+  def validateSourceIsReadable(source: File): ValidationResult[File] =
+    if(source.canRead) source.validNec
+    else ConfigValidation.SourceIsNotReadable.invalidNec
+
+  def validateSource(source: File): ValidationResult[File] =
+    validateSourceIsDirectory(source).andThen(s => validateSourceIsReadable(s))
+
+  def validateBucket(bucket: Bucket): ValidationResult[Bucket] =
+    if (bucket.name.isEmpty) ConfigValidation.BucketNameIsMissing.invalidNec
+    else bucket.validNec
+
+  def validateConfig(config: Config): Validated[NonEmptyChain[ConfigValidation], Config] =
+    (
+      validateSource(config.source),
+      validateBucket(config.bucket)
+    ).mapN((_, _) => config)
+}
+
+object ConfigValidator extends ConfigValidator

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
@@ -18,12 +18,12 @@ trait ConfigurationBuilder {
 
   private val defaultConfig: Config = Config(source = pwdFile)
 
-  def apply(priorityOptions: Seq[ConfigOption]): IO[Either[NonEmptyChain[ConfigValidation], Config]] = {
+  def buildConfig(priorityOptions: Seq[ConfigOption]): IO[Either[NonEmptyChain[ConfigValidation], Config]] = {
     val source = findSource(priorityOptions)
     for {
       options <- sourceOptions(source)
       collected = priorityOptions ++ options
-      config = buildConfig(collected)
+      config = collateOptions(collected)
     } yield validateConfig(config).toEither
   }
 
@@ -39,7 +39,7 @@ trait ConfigurationBuilder {
   private def readFile(source: File, filename: String): IO[Seq[ConfigOption]] =
     ParseConfigFile(source.toPath.resolve(filename))
 
-  private def buildConfig(configOptions: Seq[ConfigOption]): Config =
+  private def collateOptions(configOptions: Seq[ConfigOption]): Config =
     configOptions.foldRight(defaultConfig)((co, c) => co.update(c))
 }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
@@ -7,6 +7,7 @@ import cats.data.NonEmptyChain
 import cats.effect.IO
 import net.kemitix.thorp.core.ConfigValidator.validateConfig
 import net.kemitix.thorp.domain.Config
+import net.kemitix.thorp.core.ParseConfigFile.parseFile
 
 /**
   * Builds a configuration from settings in a file within the
@@ -37,7 +38,7 @@ trait ConfigurationBuilder {
     readFile(source, ".thorp.conf")
 
   private def readFile(source: File, filename: String): IO[Seq[ConfigOption]] =
-    ParseConfigFile(source.toPath.resolve(filename))
+    parseFile(source.toPath.resolve(filename))
 
   private def collateOptions(configOptions: Seq[ConfigOption]): Config =
     configOptions.foldRight(defaultConfig)((co, c) => co.update(c))

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
@@ -1,0 +1,25 @@
+package net.kemitix.thorp.core
+
+import java.io.File
+import java.nio.file.Paths
+
+import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import net.kemitix.thorp.domain.Config
+
+/**
+  * Builds a configuration from settings in a file within the
+  * `source` directory and from supplied configuration options.
+  */
+trait ConfigurationBuilder {
+
+  val defaultConfig: Config =
+    Config(source = Paths.get(System.getenv("PWD")).toFile)
+
+  def apply(configOptions: Seq[ConfigOption]): Either[NonEmptyChain[ConfigValidation], Config] = {
+    val config = configOptions.foldRight(defaultConfig)((co, c) => co.update(c))
+    ConfigValidator.validateConfig(config).toEither
+  }
+
+}
+
+object ConfigurationBuilder extends ConfigurationBuilder

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
@@ -3,8 +3,9 @@ package net.kemitix.thorp.core
 import java.io.File
 import java.nio.file.Paths
 
-import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import cats.data.NonEmptyChain
 import net.kemitix.thorp.domain.Config
+import net.kemitix.thorp.core.ConfigValidator._
 
 /**
   * Builds a configuration from settings in a file within the
@@ -12,13 +13,15 @@ import net.kemitix.thorp.domain.Config
   */
 trait ConfigurationBuilder {
 
-  val defaultConfig: Config =
-    Config(source = Paths.get(System.getenv("PWD")).toFile)
+  private val pwdFile: File = Paths.get(System.getenv("PWD")).toFile
 
-  def apply(configOptions: Seq[ConfigOption]): Either[NonEmptyChain[ConfigValidation], Config] = {
-    val config = configOptions.foldRight(defaultConfig)((co, c) => co.update(c))
-    ConfigValidator.validateConfig(config).toEither
-  }
+  private val defaultConfig: Config = Config(source = pwdFile)
+
+  def apply(configOptions: Seq[ConfigOption]): Either[NonEmptyChain[ConfigValidation], Config] =
+    validateConfig(buildConfig(configOptions)).toEither
+
+  private def buildConfig(configOptions: Seq[ConfigOption]) =
+    configOptions.foldRight(defaultConfig)((co, c) => co.update(c))
 
 }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
@@ -4,7 +4,7 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.regex.Pattern
 
 import cats.effect.IO
-import net.kemitix.thorp.core.ConfigOption.{Bucket, Debug, Exclude, Include, Prefix, Source}
+import net.kemitix.thorp.core.ConfigOption._
 
 import scala.collection.JavaConverters._
 

--- a/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
@@ -1,0 +1,48 @@
+package net.kemitix.thorp.core
+
+import java.nio.file.{Files, Path, Paths}
+import java.util.regex.Pattern
+
+import cats.effect.IO
+import net.kemitix.thorp.core.ConfigOption.{Bucket, Debug, Exclude, Include, Prefix, Source}
+
+import scala.collection.JavaConverters._
+
+trait ParseConfigFile {
+
+  def apply(filename: Path): IO[Seq[ConfigOption]] =
+    readFile(filename).map(parseLines)
+
+  private def readFile(filename: Path) =
+    IO {
+      val lines = Files.lines(filename)
+      val scala = lines.iterator.asScala.toList
+      lines.close()
+      scala
+    }
+
+  private def parseLines(lines: List[String]) =
+    lines.flatMap(parseLine)
+
+  private val format = Pattern.compile("^(<?:key>)\\s*=\\s*(<?:value>)\\s*$")
+
+  private def parseLine(str: String) =
+    format.matcher(str) match {
+      case m if m.matches => parse(m.group("key"), m.group("value"))
+      case _ => None
+    }
+
+  private def parse(key: String, value: String): Option[ConfigOption] =
+    key match {
+      case "source" => Some(Source(Paths.get(value)))
+      case "bucket" => Some(Bucket(value))
+      case "prefix" => Some(Prefix(value))
+      case "include" => Some(Include(value))
+      case "exclude" => Some(Exclude(value))
+      case "debug" => Some(Debug())
+      case _ => None
+    }
+
+}
+
+object ParseConfigFile extends ParseConfigFile

--- a/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
@@ -1,46 +1,25 @@
 package net.kemitix.thorp.core
 
-import java.nio.file.{Files, Path, Paths}
-import java.util.regex.Pattern
+import java.nio.file.{Files, Path}
 
 import cats.effect.IO
-import net.kemitix.thorp.core.ConfigOption._
 
 import scala.collection.JavaConverters._
 
 trait ParseConfigFile {
 
   def apply(filename: Path): IO[Seq[ConfigOption]] =
-    readFile(filename).map(parseLines)
+    readFile(filename).map(ParseConfigLines(_))
 
   private def readFile(filename: Path) =
     IO {
-      val lines = Files.lines(filename)
-      val scala = lines.iterator.asScala.toList
-      lines.close()
-      scala
-    }
-
-  private def parseLines(lines: List[String]) =
-    lines.flatMap(parseLine)
-
-  private val format = Pattern.compile("^(<?:key>)\\s*=\\s*(<?:value>)\\s*$")
-
-  private def parseLine(str: String) =
-    format.matcher(str) match {
-      case m if m.matches => parse(m.group("key"), m.group("value"))
-      case _ => None
-    }
-
-  private def parse(key: String, value: String): Option[ConfigOption] =
-    key match {
-      case "source" => Some(Source(Paths.get(value)))
-      case "bucket" => Some(Bucket(value))
-      case "prefix" => Some(Prefix(value))
-      case "include" => Some(Include(value))
-      case "exclude" => Some(Exclude(value))
-      case "debug" => Some(Debug())
-      case _ => None
+      if (Files.exists(filename)) {
+        val lines = Files.lines(filename)
+        val scala = lines.iterator.asScala.toList
+        lines.close()
+        scala
+      } else
+        List()
     }
 
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
@@ -11,16 +11,17 @@ trait ParseConfigFile {
   def parseFile(filename: Path): IO[Seq[ConfigOption]] =
     readFile(filename).map(ParseConfigLines.parseLines)
 
-  private def readFile(filename: Path) =
-    IO {
-      if (Files.exists(filename)) {
-        val lines = Files.lines(filename)
-        val scala = lines.iterator.asScala.toList
-        lines.close()
-        scala
-      } else
-        List()
-    }
+  private def readFile(filename: Path) = {
+    if (Files.exists(filename)) readFileThatExists(filename)
+    else IO.pure(List())
+  }
+
+  private def readFileThatExists(filename: Path) =
+    for {
+      lines <- IO(Files.lines(filename))
+      list = lines.iterator.asScala.toList
+      _ <- IO(lines.close())
+    } yield list
 
 }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ParseConfigFile.scala
@@ -8,8 +8,8 @@ import scala.collection.JavaConverters._
 
 trait ParseConfigFile {
 
-  def apply(filename: Path): IO[Seq[ConfigOption]] =
-    readFile(filename).map(ParseConfigLines(_))
+  def parseFile(filename: Path): IO[Seq[ConfigOption]] =
+    readFile(filename).map(ParseConfigLines.parseLines)
 
   private def readFile(filename: Path) =
     IO {

--- a/core/src/main/scala/net/kemitix/thorp/core/ParseConfigLines.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ParseConfigLines.scala
@@ -7,7 +7,7 @@ import net.kemitix.thorp.core.ConfigOption.{Bucket, Debug, Exclude, Include, Pre
 
 trait ParseConfigLines {
 
-  def apply(lines: List[String]): List[ConfigOption] =
+  def parseLines(lines: List[String]): List[ConfigOption] =
     lines.flatMap(parseLine)
 
   private val pattern = "^\\s*(?<key>\\S*)\\s*=\\s*(?<value>\\S*)\\s*$"
@@ -15,7 +15,7 @@ trait ParseConfigLines {
 
   private def parseLine(str: String) =
     format.matcher(str) match {
-      case m if m.matches => parse(m.group("key"), m.group("value"))
+      case m if m.matches => parseKeyValue(m.group("key"), m.group("value"))
       case _ =>None
     }
 
@@ -27,7 +27,7 @@ trait ParseConfigLines {
       case _ => false
     }
 
-  private def parse(key: String, value: String): Option[ConfigOption] =
+  private def parseKeyValue(key: String, value: String): Option[ConfigOption] =
     key.toLowerCase match {
       case "source" => Some(Source(Paths.get(value)))
       case "bucket" => Some(Bucket(value))

--- a/core/src/main/scala/net/kemitix/thorp/core/ParseConfigLines.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ParseConfigLines.scala
@@ -1,0 +1,43 @@
+package net.kemitix.thorp.core
+
+import java.nio.file.Paths
+import java.util.regex.Pattern
+
+import net.kemitix.thorp.core.ConfigOption.{Bucket, Debug, Exclude, Include, Prefix, Source}
+
+trait ParseConfigLines {
+
+  def apply(lines: List[String]): List[ConfigOption] =
+    lines.flatMap(parseLine)
+
+  private val pattern = "^\\s*(?<key>\\S*)\\s*=\\s*(?<value>\\S*)\\s*$"
+  private val format = Pattern.compile(pattern)
+
+  private def parseLine(str: String) =
+    format.matcher(str) match {
+      case m if m.matches => parse(m.group("key"), m.group("value"))
+      case _ =>None
+    }
+
+  def truthy(value: String): Boolean =
+    value.toLowerCase match {
+      case "true" => true
+      case "yes" => true
+      case "enabled" => true
+      case _ => false
+    }
+
+  private def parse(key: String, value: String): Option[ConfigOption] =
+    key.toLowerCase match {
+      case "source" => Some(Source(Paths.get(value)))
+      case "bucket" => Some(Bucket(value))
+      case "prefix" => Some(Prefix(value))
+      case "include" => Some(Include(value))
+      case "exclude" => Some(Exclude(value))
+      case "debug" => if (truthy(value)) Some(Debug()) else None
+      case _ => None
+    }
+
+}
+
+object ParseConfigLines extends ParseConfigLines

--- a/core/src/main/scala/net/kemitix/thorp/core/Sync.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Sync.scala
@@ -6,10 +6,10 @@ import net.kemitix.thorp.aws.api.{S3Action, S3Client}
 import net.kemitix.thorp.core.Action.ToDelete
 import net.kemitix.thorp.core.ActionGenerator.createActions
 import net.kemitix.thorp.core.ActionSubmitter.submitAction
+import net.kemitix.thorp.core.ConfigurationBuilder.buildConfig
 import net.kemitix.thorp.core.LocalFileStream.findFiles
 import net.kemitix.thorp.core.S3MetaDataEnricher.getMetadata
 import net.kemitix.thorp.core.SyncLogging.{logFileScan, logRunFinished, logRunStart}
-import net.kemitix.thorp.core.ConfigurationBuilder.buildConfig
 import net.kemitix.thorp.domain._
 
 trait Sync {
@@ -27,13 +27,13 @@ trait Sync {
       case Left(errors) => IO.pure(Left(errorMessages(errors.toList)))
       case Right(config) =>
         for {
-          _ <- Sync.run(config, s3Client, defaultLogger.withDebug(config.debug))
+          _ <- run(config, s3Client, defaultLogger.withDebug(config.debug))
         } yield Right(())
     }
 
-  def run(cliConfig: Config,
-          s3Client: S3Client,
-          logger: Logger): IO[Unit] = {
+  private def run(cliConfig: Config,
+                  s3Client: S3Client,
+                  logger: Logger): IO[Unit] = {
 
     implicit val c: Config = cliConfig
     implicit val l: Logger = logger

--- a/core/src/main/scala/net/kemitix/thorp/core/Sync.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Sync.scala
@@ -9,6 +9,7 @@ import net.kemitix.thorp.core.ActionSubmitter.submitAction
 import net.kemitix.thorp.core.LocalFileStream.findFiles
 import net.kemitix.thorp.core.S3MetaDataEnricher.getMetadata
 import net.kemitix.thorp.core.SyncLogging.{logFileScan, logRunFinished, logRunStart}
+import net.kemitix.thorp.core.ConfigurationBuilder.buildConfig
 import net.kemitix.thorp.domain._
 
 trait Sync {
@@ -22,7 +23,7 @@ trait Sync {
   def apply(s3Client: S3Client)
            (configOptions: Seq[ConfigOption])
            (implicit defaultLogger: Logger): IO[Either[List[String], Unit]] =
-    ConfigurationBuilder(configOptions).flatMap {
+    buildConfig(configOptions).flatMap {
       case Left(errors) => IO.pure(Left(errorMessages(errors.toList)))
       case Right(config) =>
         for {

--- a/core/src/main/scala/net/kemitix/thorp/core/Sync.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Sync.scala
@@ -13,11 +13,11 @@ import net.kemitix.thorp.domain._
 
 object Sync {
 
-  def run[M[_]: Monad](config: Config,
+  def run[M[_]: Monad](cliConfig: Config,
                        s3Client: S3Client[M])
                       (implicit logger: Logger[M]): M[Unit] = {
 
-    implicit val c: Config = config
+    implicit val c: Config = cliConfig
 
     def metaData(s3Data: S3ObjectsData, sFiles: Stream[LocalFile]) =
       Monad[M].pure(sFiles.map(file => getMetadata(file, s3Data)))

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncLogging.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncLogging.scala
@@ -1,7 +1,6 @@
 package net.kemitix.thorp.core
 
-import cats.Monad
-import cats.implicits._
+import cats.effect.IO
 import net.kemitix.thorp.aws.api.S3Action
 import net.kemitix.thorp.aws.api.S3Action.{CopyS3Action, DeleteS3Action, ErroredS3Action, UploadS3Action}
 import net.kemitix.thorp.domain.{Config, Logger}
@@ -9,17 +8,17 @@ import net.kemitix.thorp.domain.{Config, Logger}
 // Logging for the Sync class
 object SyncLogging {
 
-  def logRunStart[M[_]: Monad](implicit c: Config,
-                               logger: Logger[M]): M[Unit] =
+  def logRunStart(implicit c: Config,
+                  logger: Logger): IO[Unit] =
     logger.info(s"Bucket: ${c.bucket.name}, Prefix: ${c.prefix.key}, Source: ${c.source}, ")
 
-  def logFileScan[M[_]: Monad](implicit c: Config,
-                               logger: Logger[M]): M[Unit] =
+  def logFileScan(implicit c: Config,
+                  logger: Logger): IO[Unit] =
     logger.info(s"Scanning local files: ${c.source}...")
 
-  def logRunFinished[M[_]: Monad](actions: Stream[S3Action])
-                                 (implicit c: Config,
-                                  logger: Logger[M]): M[Unit] = {
+  def logRunFinished(actions: Stream[S3Action])
+                    (implicit c: Config,
+                     logger: Logger): IO[Unit] = {
     val counters = actions.foldLeft(Counters())(countActivities)
     for {
       _ <- logger.info(s"Uploaded ${counters.uploaded} files")

--- a/core/src/test/resources/net/kemitix/thorp/core/invalid-config
+++ b/core/src/test/resources/net/kemitix/thorp/core/invalid-config
@@ -1,0 +1,1 @@
+no valid = config items

--- a/core/src/test/resources/net/kemitix/thorp/core/simple-config
+++ b/core/src/test/resources/net/kemitix/thorp/core/simple-config
@@ -1,0 +1,2 @@
+source = /path/to/source
+bucket = bucket-name

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyLogger.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyLogger.scala
@@ -1,18 +1,18 @@
 package net.kemitix.thorp.core
 
-import cats.Monad
+import cats.effect.IO
 import net.kemitix.thorp.domain.Logger
 
-class DummyLogger[M[_]: Monad] extends Logger[M] {
+class DummyLogger extends Logger {
 
-  override def debug(message: => String): M[Unit] = Monad[M].unit
+  override def debug(message: => String): IO[Unit] = IO.unit
 
-  override def info(message: =>String): M[Unit] = Monad[M].unit
+  override def info(message: =>String): IO[Unit] = IO.unit
 
-  override def warn(message: String): M[Unit] = Monad[M].unit
+  override def warn(message: String): IO[Unit] = IO.unit
 
-  override def error(message: String): M[Unit] = Monad[M].unit
+  override def error(message: String): IO[Unit] = IO.unit
 
-  override def withDebug(debug: Boolean): Logger[M] = this
+  override def withDebug(debug: Boolean): Logger = this
 
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyLogger.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyLogger.scala
@@ -13,4 +13,6 @@ class DummyLogger[M[_]: Monad] extends Logger[M] {
 
   override def error(message: String): M[Unit] = Monad[M].unit
 
+  override def withDebug(debug: Boolean): Logger[M] = this
+
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
@@ -2,7 +2,7 @@ package net.kemitix.thorp.core
 
 import java.io.File
 
-import cats.Id
+import cats.effect.IO
 import net.kemitix.thorp.domain.{Config, LocalFile, Logger, MD5Hash}
 import org.scalatest.FunSpec
 
@@ -10,13 +10,13 @@ class LocalFileStreamSuite extends FunSpec {
 
   val uploadResource = Resource(this, "upload")
   implicit val config: Config = Config(source = uploadResource)
-  implicit private val logger: Logger[Id] = new DummyLogger[Id]
-  val md5HashGenerator: File => Id[MD5Hash] = file => MD5HashGenerator.md5File[Id](file)
+  implicit private val logger: Logger = new DummyLogger
+  val md5HashGenerator: File => IO[MD5Hash] = file => MD5HashGenerator.md5File(file)
 
   describe("findFiles") {
     it("should find all files") {
       val result: Set[String] =
-        LocalFileStream.findFiles[Id](uploadResource, md5HashGenerator).toSet
+        LocalFileStream.findFiles(uploadResource, md5HashGenerator).unsafeRunSync.toSet
           .map { x: LocalFile => x.relative.toString }
       assertResult(Set("subdir/leaf-file", "root-file"))(result)
     }

--- a/core/src/test/scala/net/kemitix/thorp/core/MD5HashGeneratorTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/MD5HashGeneratorTest.scala
@@ -1,6 +1,5 @@
 package net.kemitix.thorp.core
 
-import cats.Id
 import net.kemitix.thorp.core.MD5HashData.rootHash
 import net.kemitix.thorp.domain._
 import org.scalatest.FunSpec
@@ -10,12 +9,12 @@ class MD5HashGeneratorTest extends FunSpec {
   private val source = Resource(this, "upload")
   private val prefix = RemoteKey("prefix")
   implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
-  implicit private val logger: Logger[Id] = new DummyLogger[Id]
+  implicit private val logger: Logger = new DummyLogger
 
     describe("read a small file (smaller than buffer)") {
       val file = Resource(this, "upload/root-file")
       it("should generate the correct hash") {
-        val result = MD5HashGenerator.md5File[Id](file)
+        val result = MD5HashGenerator.md5File(file).unsafeRunSync
         assertResult(rootHash)(result)
       }
     }
@@ -23,7 +22,7 @@ class MD5HashGeneratorTest extends FunSpec {
       val file = Resource(this, "big-file")
       it("should generate the correct hash") {
         val expected = MD5Hash("b1ab1f7680138e6db7309200584e35d8")
-        val result = MD5HashGenerator.md5File[Id](file)
+        val result = MD5HashGenerator.md5File(file).unsafeRunSync
         assertResult(expected)(result)
       }
     }

--- a/core/src/test/scala/net/kemitix/thorp/core/ParseConfigFileTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ParseConfigFileTest.scala
@@ -1,0 +1,37 @@
+package net.kemitix.thorp.core
+
+import java.nio.file.{Path, Paths}
+
+import org.scalatest.FunSpec
+
+class ParseConfigFileTest extends FunSpec {
+
+  private def invoke(filename: Path) = ParseConfigFile.parseFile(filename).unsafeRunSync
+  private val empty = List()
+
+  describe("parse a missing file") {
+    val filename = Paths.get("/path/to/missing/file")
+    it("should return no options") {
+      assertResult(empty)(invoke(filename))
+    }
+  }
+  describe("parse an empty file") {
+    val filename = Resource(this, "empty-file").toPath
+    it("should return no options") {
+      assertResult(empty)(invoke(filename))
+    }
+  }
+  describe("parse a file with no valid entries") {
+    val filename = Resource(this, "invalid-config").toPath
+    it("should return no options") {
+      assertResult(empty)(invoke(filename))
+    }
+  }
+  describe("parse a file with properties") {
+    val filename = Resource(this, "simple-config").toPath
+    val expected = List(ConfigOption.Source(Paths.get("/path/to/source")), ConfigOption.Bucket("bucket-name"))
+    it("should return some options") {
+      assertResult(expected)(invoke(filename))
+    }
+  }
+}

--- a/core/src/test/scala/net/kemitix/thorp/core/ParseConfigLinesTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ParseConfigLinesTest.scala
@@ -1,0 +1,74 @@
+package net.kemitix.thorp.core
+
+import java.nio.file.Paths
+
+import org.scalatest.FunSpec
+
+class ParseConfigLinesTest extends FunSpec {
+
+  describe("parse single lines") {
+    describe("source") {
+      it("should parse") {
+        val expected = List(ConfigOption.Source(Paths.get("/path/to/source")))
+        val result = ParseConfigLines(List("source = /path/to/source"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("bucket") {
+      it("should parse") {
+        val expected = List(ConfigOption.Bucket("bucket-name"))
+        val result = ParseConfigLines(List("bucket = bucket-name"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("prefix") {
+      it("should parse") {
+        val expected = List(ConfigOption.Prefix("prefix/to/files"))
+        val result = ParseConfigLines(List("prefix = prefix/to/files"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("include") {
+      it("should parse") {
+        val expected = List(ConfigOption.Include("path/to/include"))
+        val result = ParseConfigLines(List("include = path/to/include"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("exclude") {
+      it("should parse") {
+        val expected = List(ConfigOption.Exclude("path/to/exclude"))
+        val result = ParseConfigLines(List("exclude = path/to/exclude"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("debug - true") {
+      it("should parse") {
+        val expected = List(ConfigOption.Debug())
+        val result = ParseConfigLines(List("debug = true"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("debug - false") {
+      it("should parse") {
+        val expected = List()
+        val result = ParseConfigLines(List("debug = false"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("comment line") {
+      it("should be ignored") {
+        val expected = List()
+        val result = ParseConfigLines(List("# ignore me"))
+        assertResult(expected)(result)
+      }
+    }
+    describe("unrecognised option") {
+      it("should be ignored") {
+        val expected = List()
+        val result = ParseConfigLines(List("unsupported = option"))
+        assertResult(expected)(result)
+      }
+    }
+  }
+}

--- a/core/src/test/scala/net/kemitix/thorp/core/ParseConfigLinesTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ParseConfigLinesTest.scala
@@ -10,63 +10,63 @@ class ParseConfigLinesTest extends FunSpec {
     describe("source") {
       it("should parse") {
         val expected = List(ConfigOption.Source(Paths.get("/path/to/source")))
-        val result = ParseConfigLines(List("source = /path/to/source"))
+        val result = ParseConfigLines.parseLines(List("source = /path/to/source"))
         assertResult(expected)(result)
       }
     }
     describe("bucket") {
       it("should parse") {
         val expected = List(ConfigOption.Bucket("bucket-name"))
-        val result = ParseConfigLines(List("bucket = bucket-name"))
+        val result = ParseConfigLines.parseLines(List("bucket = bucket-name"))
         assertResult(expected)(result)
       }
     }
     describe("prefix") {
       it("should parse") {
         val expected = List(ConfigOption.Prefix("prefix/to/files"))
-        val result = ParseConfigLines(List("prefix = prefix/to/files"))
+        val result = ParseConfigLines.parseLines(List("prefix = prefix/to/files"))
         assertResult(expected)(result)
       }
     }
     describe("include") {
       it("should parse") {
         val expected = List(ConfigOption.Include("path/to/include"))
-        val result = ParseConfigLines(List("include = path/to/include"))
+        val result = ParseConfigLines.parseLines(List("include = path/to/include"))
         assertResult(expected)(result)
       }
     }
     describe("exclude") {
       it("should parse") {
         val expected = List(ConfigOption.Exclude("path/to/exclude"))
-        val result = ParseConfigLines(List("exclude = path/to/exclude"))
+        val result = ParseConfigLines.parseLines(List("exclude = path/to/exclude"))
         assertResult(expected)(result)
       }
     }
     describe("debug - true") {
       it("should parse") {
         val expected = List(ConfigOption.Debug())
-        val result = ParseConfigLines(List("debug = true"))
+        val result = ParseConfigLines.parseLines(List("debug = true"))
         assertResult(expected)(result)
       }
     }
     describe("debug - false") {
       it("should parse") {
         val expected = List()
-        val result = ParseConfigLines(List("debug = false"))
+        val result = ParseConfigLines.parseLines(List("debug = false"))
         assertResult(expected)(result)
       }
     }
     describe("comment line") {
       it("should be ignored") {
         val expected = List()
-        val result = ParseConfigLines(List("# ignore me"))
+        val result = ParseConfigLines.parseLines(List("# ignore me"))
         assertResult(expected)(result)
       }
     }
     describe("unrecognised option") {
       it("should be ignored") {
         val expected = List()
-        val result = ParseConfigLines(List("unsupported = option"))
+        val result = ParseConfigLines.parseLines(List("unsupported = option"))
         assertResult(expected)(result)
       }
     }

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -3,7 +3,7 @@ package net.kemitix.thorp.core
 import java.io.File
 import java.time.Instant
 
-import cats.Id
+import cats.effect.IO
 import net.kemitix.thorp.aws.api.S3Action.{CopyS3Action, DeleteS3Action, UploadS3Action}
 import net.kemitix.thorp.aws.api.{S3Client, UploadProgressListener}
 import net.kemitix.thorp.core.MD5HashData.{leafHash, rootHash}
@@ -17,7 +17,7 @@ class SyncSuite
   private val source = Resource(this, "upload")
   private val prefix = RemoteKey("prefix")
   val config = Config(Bucket("bucket"), prefix, source = source)
-  implicit private val logger: Logger[Id] = new DummyLogger[Id]
+  implicit private val logger: Logger = new DummyLogger
   private val lastModified = LastModified(Instant.now)
 
   def putObjectRequest(bucket: Bucket, remoteKey: RemoteKey, localFile: LocalFile): (String, String, File) =
@@ -32,7 +32,7 @@ class SyncSuite
       val s3Client = new RecordingClient(testBucket, S3ObjectsData(
         byHash = Map(),
         byKey = Map()))
-      Sync.run(config, s3Client)
+      Sync.run(config, s3Client, logger)
       it("uploads all files") {
         val expectedUploads = Map(
           "subdir/leaf-file" -> leafRemoteKey,
@@ -58,7 +58,7 @@ class SyncSuite
           RemoteKey("prefix/root-file") -> HashModified(rootHash, lastModified),
           RemoteKey("prefix/subdir/leaf-file") -> HashModified(leafHash, lastModified)))
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client)
+      Sync.run(config, s3Client, logger)
       it("uploads nothing") {
         val expectedUploads = Map()
         assertResult(expectedUploads)(s3Client.uploadsRecord)
@@ -82,7 +82,7 @@ class SyncSuite
           RemoteKey("prefix/root-file-old") -> HashModified(rootHash, lastModified),
           RemoteKey("prefix/subdir/leaf-file") -> HashModified(leafHash, lastModified)))
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client)
+      Sync.run(config, s3Client, logger)
       it("uploads nothing") {
         val expectedUploads = Map()
         assertResult(expectedUploads)(s3Client.uploadsRecord)
@@ -110,7 +110,7 @@ class SyncSuite
         byKey = Map(
           deletedKey -> HashModified(deletedHash, lastModified)))
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client)
+      Sync.run(config, s3Client, logger)
       it("deleted key") {
         val expectedDeletions = Set(deletedKey)
         assertResult(expectedDeletions)(s3Client.deletionsRecord)
@@ -120,7 +120,7 @@ class SyncSuite
       val config: Config = Config(Bucket("bucket"), prefix, source = source, filters = List(Exclude("leaf")))
       val s3ObjectsData = S3ObjectsData(Map(), Map())
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client)
+      Sync.run(config, s3Client, logger)
       it("is not uploaded") {
         val expectedUploads = Map(
           "root-file" -> rootRemoteKey
@@ -132,7 +132,7 @@ class SyncSuite
 
   class RecordingClient(testBucket: Bucket,
                         s3ObjectsData: S3ObjectsData)
-    extends S3Client[Id] {
+    extends S3Client {
 
     var uploadsRecord: Map[String, RemoteKey] = Map()
     var copiesRecord: Map[RemoteKey, RemoteKey] = Map()
@@ -140,8 +140,8 @@ class SyncSuite
 
     override def listObjects(bucket: Bucket,
                              prefix: RemoteKey)
-                            (implicit logger: Logger[Id]): S3ObjectsData =
-      s3ObjectsData
+                            (implicit logger: Logger): IO[S3ObjectsData] =
+      IO.pure(s3ObjectsData)
 
     override def upload(localFile: LocalFile,
                         bucket: Bucket,
@@ -149,28 +149,28 @@ class SyncSuite
                         multiPartThreshold: Long,
                         tryCount: Int,
                         maxRetries: Int)
-                       (implicit logger: Logger[Id]): UploadS3Action = {
+                       (implicit logger: Logger): IO[UploadS3Action] = {
       if (bucket == testBucket)
         uploadsRecord += (localFile.relative.toString -> localFile.remoteKey)
-      UploadS3Action(localFile.remoteKey, MD5Hash("some hash value"))
+      IO.pure(UploadS3Action(localFile.remoteKey, MD5Hash("some hash value")))
     }
 
     override def copy(bucket: Bucket,
                       sourceKey: RemoteKey,
                       hash: MD5Hash,
                       targetKey: RemoteKey
-                     )(implicit logger: Logger[Id]): CopyS3Action = {
+                     )(implicit logger: Logger): IO[CopyS3Action] = {
       if (bucket == testBucket)
         copiesRecord += (sourceKey -> targetKey)
-      CopyS3Action(targetKey)
+      IO.pure(CopyS3Action(targetKey))
     }
 
     override def delete(bucket: Bucket,
                         remoteKey: RemoteKey
-                       )(implicit logger: Logger[Id]): DeleteS3Action = {
+                       )(implicit logger: Logger): IO[DeleteS3Action] = {
       if (bucket == testBucket)
         deletionsRecord += remoteKey
-      DeleteS3Action(remoteKey)
+      IO.pure(DeleteS3Action(remoteKey))
     }
   }
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -16,23 +16,32 @@ class SyncSuite
 
   private val source = Resource(this, "upload")
   private val prefix = RemoteKey("prefix")
-  val config = Config(Bucket("bucket"), prefix, source = source)
+  private val configOptions = List(
+    ConfigOption.Source(source.toPath),
+    ConfigOption.Bucket("bucket"),
+    ConfigOption.Prefix("prefix")
+  )
   implicit private val logger: Logger = new DummyLogger
   private val lastModified = LastModified(Instant.now)
 
   def putObjectRequest(bucket: Bucket, remoteKey: RemoteKey, localFile: LocalFile): (String, String, File) =
     (bucket.name, remoteKey.key, localFile.file)
 
-  describe("run") {
+  describe("Sync.apply") {
     val testBucket = Bucket("bucket")
     // source contains the files root-file and subdir/leaf-file
     val rootRemoteKey = RemoteKey("prefix/root-file")
     val leafRemoteKey = RemoteKey("prefix/subdir/leaf-file")
+
+    def invokeSubject(s3Client: RecordingClient, configOptions: List[ConfigOption]) = {
+      Sync(s3Client)(configOptions).unsafeRunSync
+    }
+
     describe("when all files should be uploaded") {
       val s3Client = new RecordingClient(testBucket, S3ObjectsData(
         byHash = Map(),
         byKey = Map()))
-      Sync.run(config, s3Client, logger)
+      invokeSubject(s3Client, configOptions)
       it("uploads all files") {
         val expectedUploads = Map(
           "subdir/leaf-file" -> leafRemoteKey,
@@ -58,7 +67,7 @@ class SyncSuite
           RemoteKey("prefix/root-file") -> HashModified(rootHash, lastModified),
           RemoteKey("prefix/subdir/leaf-file") -> HashModified(leafHash, lastModified)))
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client, logger)
+      invokeSubject(s3Client, configOptions)
       it("uploads nothing") {
         val expectedUploads = Map()
         assertResult(expectedUploads)(s3Client.uploadsRecord)
@@ -82,7 +91,7 @@ class SyncSuite
           RemoteKey("prefix/root-file-old") -> HashModified(rootHash, lastModified),
           RemoteKey("prefix/subdir/leaf-file") -> HashModified(leafHash, lastModified)))
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client, logger)
+      invokeSubject(s3Client, configOptions)
       it("uploads nothing") {
         val expectedUploads = Map()
         assertResult(expectedUploads)(s3Client.uploadsRecord)
@@ -110,17 +119,16 @@ class SyncSuite
         byKey = Map(
           deletedKey -> HashModified(deletedHash, lastModified)))
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client, logger)
+      invokeSubject(s3Client, configOptions)
       it("deleted key") {
         val expectedDeletions = Set(deletedKey)
         assertResult(expectedDeletions)(s3Client.deletionsRecord)
       }
     }
     describe("when a file is excluded") {
-      val config: Config = Config(Bucket("bucket"), prefix, source = source, filters = List(Exclude("leaf")))
       val s3ObjectsData = S3ObjectsData(Map(), Map())
       val s3Client = new RecordingClient(testBucket, s3ObjectsData)
-      Sync.run(config, s3Client, logger)
+      invokeSubject(s3Client, ConfigOption.Exclude("leaf") :: configOptions)
       it("is not uploaded") {
         val expectedUploads = Map(
           "root-file" -> rootRemoteKey

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
@@ -11,6 +11,5 @@ final case class Config(
                          debug: Boolean = false,
                          source: File
 ) {
-  require(source.isDirectory, s"Source must be a directory: $source")
   require(multiPartThreshold >= 1024 * 1024 * 5, s"Threshold for multi-part upload is 5Mb: '$multiPartThreshold'")
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Logger.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Logger.scala
@@ -2,6 +2,11 @@ package net.kemitix.thorp.domain
 
 trait Logger[M[_]] {
 
+  // returns an instance of Logger with debug set as indicated
+  // where the current Logger already matches this state, then
+  // it returns itself, unmodified
+  def withDebug(debug: Boolean): Logger[M]
+
   def debug(message: => String): M[Unit]
   def info(message: => String): M[Unit]
   def warn(message: String): M[Unit]

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Logger.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Logger.scala
@@ -1,15 +1,17 @@
 package net.kemitix.thorp.domain
 
-trait Logger[M[_]] {
+import cats.effect.IO
+
+trait Logger {
 
   // returns an instance of Logger with debug set as indicated
   // where the current Logger already matches this state, then
   // it returns itself, unmodified
-  def withDebug(debug: Boolean): Logger[M]
+  def withDebug(debug: Boolean): Logger
 
-  def debug(message: => String): M[Unit]
-  def info(message: => String): M[Unit]
-  def warn(message: String): M[Unit]
-  def error(message: String): M[Unit]
+  def debug(message: => String): IO[Unit]
+  def info(message: => String): IO[Unit]
+  def warn(message: String): IO[Unit]
+  def error(message: String): IO[Unit]
 
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
@@ -4,10 +4,21 @@ import java.io.File
 import java.nio.file.Paths
 
 final case class RemoteKey(key: String) {
+
   def asFile(source: File, prefix: RemoteKey): File =
-    source.toPath.resolve(Paths.get(prefix.key).relativize(Paths.get(key))).toFile
+    source.toPath.resolve(relativeTo(prefix)).toFile
+
+  private def relativeTo(prefix: RemoteKey) = {
+    prefix match {
+      case RemoteKey("") => Paths.get(prefix.key)
+      case _ => Paths.get(prefix.key).relativize(Paths.get(key))
+    }
+  }
+
   def isMissingLocally(source: File, prefix: RemoteKey): Boolean =
     ! asFile(source, prefix).exists
+
   def resolve(path: String): RemoteKey =
     RemoteKey(key + "/" + path)
+
 }


### PR DESCRIPTION
Read from a `.thorp.conf` file in the base of the `source` directory. This file can specify default configuration parameters, e.g. the target bucket, prefix and/or archive format. 