### PR TITLE
Add support for global and user configuration files

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,15 +9,31 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 
 ** Added
 
-   - ~-d~, ~--debug~ flag for log messages
+   - Add ~thorp-lib~ module (#66)
+   - Enable running outside of sbt (#55)
+   - ~-d~, ~--debug~ flag for log messages (#60)
+   - Read config from ~.thorp.conf~ in source directory (#71)
+   - Read config from ~$HOME/.config/thorp.conf~ and ~/etc/thorp.conf~
+     (#73)
 
 ** Changed
 
-   - Suppress Transfer event messages
+   - Rename project as 'thorp' (#75)
+   - Suppress Transfer event messages (#64)
+   - Better error message when source not found (#51)
+   - Reduced logging (#59)
+
+** Fixed
+
+   - Error when calculating md5 hash for large files (#56)
 
 ** Removed
 
-   - ~-v~ verbosity flag
+   - ~-v~ verbosity flag (#63)
+
+** Dependencies
+
+   - Upgrade ~aws-java-sdk-s3~ from ~1.11.569~ to ~1.11.570~ (#57)
 
 * [0.4.0] - 2019-06-11
 

--- a/README.org
+++ b/README.org
@@ -24,7 +24,27 @@ hash of the file contents.
       -d, --debug           Enable debug logging
   #+end_example
 
+If you don't provide a ~source~ the current diretory will be used.
+
 The ~--include~ and ~--exclude~ parameters can be used more than once.
+
+* Configuration
+
+  Configuration will be read from these files:
+
+  - Global: ~/etc/thorp.conf~
+  - User: ~~/.config/thorp.conf~
+  - Source: ~${source}/.thorp.conf~
+
+Command line arguments override those in Source, which override those
+in User, which override those Global, which override any built-in
+config.
+
+Built-in config consists of using the current working directory as the
+~source~.
+
+Note, that ~include~ and ~exclude~ are cumulative across all
+configuration files.
 
 * Behaviour
 

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigurationBuilder.scala
@@ -6,8 +6,8 @@ import java.nio.file.Paths
 import cats.data.NonEmptyChain
 import cats.effect.IO
 import net.kemitix.thorp.core.ConfigValidator.validateConfig
-import net.kemitix.thorp.domain.Config
 import net.kemitix.thorp.core.ParseConfigFile.parseFile
+import net.kemitix.thorp.domain.Config
 
 /**
   * Builds a configuration from settings in a file within the
@@ -22,8 +22,10 @@ trait ConfigurationBuilder {
   def buildConfig(priorityOptions: Seq[ConfigOption]): IO[Either[NonEmptyChain[ConfigValidation], Config]] = {
     val source = findSource(priorityOptions)
     for {
-      options <- sourceOptions(source)
-      collected = priorityOptions ++ options
+      sourceOptions <- sourceOptions(source)
+      userOptions <- userOptions()
+      globalOptions <- globalOptions()
+      collected = priorityOptions ++ sourceOptions ++ userOptions ++ globalOptions
       config = collateOptions(collected)
     } yield validateConfig(config).toEither
   }
@@ -36,6 +38,14 @@ trait ConfigurationBuilder {
 
   private def sourceOptions(source: File): IO[Seq[ConfigOption]] =
     readFile(source, ".thorp.conf")
+
+  private def userOptions(): IO[Seq[ConfigOption]] =
+    readFile(userHome, ".config/thorp.conf")
+
+  private def globalOptions(): IO[Seq[ConfigOption]] =
+    parseFile(Paths.get("/etc/thorp.conf"))
+
+  private def userHome = new File(System.getProperty("user.home"))
 
   private def readFile(source: File, filename: String): IO[Seq[ConfigOption]] =
     parseFile(source.toPath.resolve(filename))


### PR DESCRIPTION
Build on per directory configuration files, to specify configuration files for the user. (e.g. `~/.config/thorp.conf)`) and globally (e.g. `/etc/thorp.conf`).

CLI parameters override directory, which overrides user, which overrides global, which overrides built-in. 