### PR TITLE
Stackoverflow on large collections of files

### DIFF
--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -31,8 +31,8 @@ trait Program {
 
   private def handleActions(archive: ThorpArchive,
                             actions: Stream[Action]): IO[Stream[StorageQueueEvent]] =
-    actions.foldRight(Stream[IO[StorageQueueEvent]]()) {
-      (action, stream) => archive.update(action) ++ stream
+    actions.foldLeft(Stream[IO[StorageQueueEvent]]()) {
+      (stream, action) => archive.update(action) ++ stream
     }.sequence
 }
 


### PR DESCRIPTION
When scanning a new, large source (16,000+ actions required) the following, truncated, stack error is thrown.
```
[E] java.lang.StackOverflowError
[E] 	at scala.collection.LinearSeqOptimized.foldRight(LinearSeqOptimized.scala:134)
[E] 	at scala.collection.LinearSeqOptimized.foldRight$(LinearSeqOptimized.scala:133)
[E] 
[E] 	at scala.collection.LinearSeqOptimized.foldRight(LinearSeqOptimized.scala:135)
[E] 	at scala.collection.LinearSeqOptimized.foldRight$(LinearSeqOptimized.scala:133)
[E] 	at scala.collection.immutable.Stream.foldRight(Stream.scala:204)
[E] 	at scala.collection.LinearSeqOptimized.foldRight(LinearSeqOptimized.scala:135)
[E] 	at scala.collection.LinearSeqOptimized.foldRight$(LinearSeqOptimized.scala:133)
...
```
The full stack is a repitition of the last three lines, with no reference to any thorp code.