### PR TITLE
Release to sonatype using correct profile name

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]], and this project adheres to
 [[https://semver.org/spec/v2.0.0.html][Semantic Versioning]].
 
+* [0.6.1] - 2019-07-03
+
+** Fixed
+
+   - Release to sonatype using correct profile name (#102)
+
 * [0.6.0] - 2019-06-30
 
 ** Added

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 inThisBuild(List(
   organization := "net.kemitix.thorp",
-  sonatypeProfileName := "net.kemitix",
   homepage := Some(url("https://github.com/kemitix/thorp")),
   licenses := List("mit" -> url("https://opensource.org/licenses/MIT")),
   developers := List(
@@ -14,6 +13,7 @@ inThisBuild(List(
 ))
 
 val commonSettings = Seq(
+  sonatypeProfileName := "net.kemitix",
   scalaVersion := "2.12.8",
   test in assembly := {}
 )


### PR DESCRIPTION
Specifying `sonatypeProfileName` in `inThisBuild` causes the `organization` value to be used, overriding the `sonatypeProfileName` value. This causes the release plugin to attempt to upload to sonatype using a profile called `net.kemitix.throp`, which doesn't exist and thus fails.