### PR TITLE
Display total size and progress for entire run

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,7 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 
    - Add a version command-line option (#99)
    - Add a batch mode (#85)
+   - Display total size and progress for entire run (#94)
 
 * [0.6.1] - 2019-07-03
 

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -17,7 +17,8 @@ trait Program {
     } else
       for {
         syncPlan <- createPlan(cliOptions)
-        events <- handleActions(thorpArchive(cliOptions), syncPlan)
+        archive <- thorpArchive(cliOptions)
+        events <- handleActions(archive, syncPlan)
         _ <- defaultStorageService.shutdown
         _ <- SyncLogging.logRunFinished(events)
       } yield ExitCode.Success
@@ -28,7 +29,7 @@ trait Program {
     Synchronise.createPlan(defaultStorageService, defaultHashService, cliOptions).valueOrF(handleErrors)
 
   private def thorpArchive(cliOptions: ConfigOptions) =
-    UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions))
+    IO.pure(UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions)))
 
   private def handleErrors(implicit logger: Logger): List[String] => IO[SyncPlan] = {
     errors => {

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -17,12 +17,15 @@ trait Program {
     } else {
       for {
         syncPlan <- Synchronise.createPlan(defaultStorageService, defaultHashService, cliOptions).valueOrF(handleErrors)
-        events <- handleActions(UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions)), syncPlan)
+        events <- handleActions(thorpArchive(cliOptions), syncPlan)
         _ <- defaultStorageService.shutdown
         _ <- SyncLogging.logRunFinished(events)
       } yield ExitCode.Success
     }
   }
+
+  private def thorpArchive(cliOptions: ConfigOptions) =
+    UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions))
 
   private def handleErrors(implicit logger: Logger): List[String] => IO[SyncPlan] = {
     errors => {

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -25,8 +25,8 @@ trait Program extends PlanBuilder {
       } yield ExitCode.Success
   }
 
-  private def thorpArchive(cliOptions: ConfigOptions,
-                           syncPlan: SyncPlan) =
+  def thorpArchive(cliOptions: ConfigOptions,
+                           syncPlan: SyncPlan): IO[ThorpArchive] =
     IO.pure(
       UnversionedMirrorArchive.default(
         defaultStorageService,

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -31,10 +31,11 @@ trait Program {
 
   private def thorpArchive(cliOptions: ConfigOptions,
                            syncPlan: SyncPlan) =
-    IO.pure(UnversionedMirrorArchive.default(
-      defaultStorageService,
-      ConfigQuery.batchMode(cliOptions),
-      syncPlan
+    IO.pure(
+      UnversionedMirrorArchive.default(
+        defaultStorageService,
+        ConfigQuery.batchMode(cliOptions),
+        syncPlan.syncTotals
     ))
 
   private def handleErrors(implicit logger: Logger): List[String] => IO[SyncPlan] = {

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -11,10 +11,11 @@ trait Program {
 
   def run(cliOptions: ConfigOptions): IO[ExitCode] = {
     implicit val logger: Logger = new PrintLogger()
-    if (ConfigQuery.showVersion(cliOptions)) IO {
-        println(s"Thorp v${thorp.BuildInfo.version}")
-        ExitCode.Success
-    } else
+    if (ConfigQuery.showVersion(cliOptions))
+      for {
+        _ <- logger.info(s"Thorp v${thorp.BuildInfo.version}")
+      } yield ExitCode.Success
+    else
       for {
         syncPlan <- createPlan(cliOptions)
         archive <- thorpArchive(cliOptions)

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -7,7 +7,7 @@ import net.kemitix.thorp.domain.{Logger, StorageQueueEvent}
 import net.kemitix.thorp.storage.aws.S3HashService.defaultHashService
 import net.kemitix.thorp.storage.aws.S3StorageServiceBuilder.defaultStorageService
 
-trait Program extends Synchronise {
+trait Program extends PlanBuilder {
 
   def run(cliOptions: ConfigOptions): IO[ExitCode] = {
     implicit val logger: Logger = new PrintLogger()

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -42,9 +42,9 @@ trait Program {
   }
 
   private def handleActions(archive: ThorpArchive,
-                            actions: SyncPlan)
+                            syncPlan: SyncPlan)
                            (implicit l: Logger): IO[Stream[StorageQueueEvent]] =
-    actions.actions.foldLeft(Stream[IO[StorageQueueEvent]]()) {
+    syncPlan.actions.foldLeft(Stream[IO[StorageQueueEvent]]()) {
       (stream, action) => archive.update(action) ++ stream
     }.sequence
 }

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -18,7 +18,7 @@ trait Program {
     else
       for {
         syncPlan <- createPlan(cliOptions)
-        archive <- thorpArchive(cliOptions)
+        archive <- thorpArchive(cliOptions, syncPlan)
         events <- handleActions(archive, syncPlan)
         _ <- defaultStorageService.shutdown
         _ <- SyncLogging.logRunFinished(events)
@@ -29,8 +29,13 @@ trait Program {
                         (implicit l: Logger): IO[SyncPlan] =
     Synchronise.createPlan(defaultStorageService, defaultHashService, cliOptions).valueOrF(handleErrors)
 
-  private def thorpArchive(cliOptions: ConfigOptions) =
-    IO.pure(UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions)))
+  private def thorpArchive(cliOptions: ConfigOptions,
+                           syncPlan: SyncPlan) =
+    IO.pure(UnversionedMirrorArchive.default(
+      defaultStorageService,
+      ConfigQuery.batchMode(cliOptions),
+      syncPlan
+    ))
 
   private def handleErrors(implicit logger: Logger): List[String] => IO[SyncPlan] = {
     errors => {

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -14,15 +14,18 @@ trait Program {
     if (ConfigQuery.showVersion(cliOptions)) IO {
         println(s"Thorp v${thorp.BuildInfo.version}")
         ExitCode.Success
-    } else {
+    } else
       for {
-        syncPlan <- Synchronise.createPlan(defaultStorageService, defaultHashService, cliOptions).valueOrF(handleErrors)
+        syncPlan <- createPlan(cliOptions)
         events <- handleActions(thorpArchive(cliOptions), syncPlan)
         _ <- defaultStorageService.shutdown
         _ <- SyncLogging.logRunFinished(events)
       } yield ExitCode.Success
-    }
   }
+
+  private def createPlan(cliOptions: ConfigOptions)
+                        (implicit l: Logger): IO[SyncPlan] =
+    Synchronise.createPlan(defaultStorageService, defaultHashService, cliOptions).valueOrF(handleErrors)
 
   private def thorpArchive(cliOptions: ConfigOptions) =
     UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions))

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -44,9 +44,11 @@ trait Program {
   private def handleActions(archive: ThorpArchive,
                             syncPlan: SyncPlan)
                            (implicit l: Logger): IO[Stream[StorageQueueEvent]] =
-    syncPlan.actions.foldLeft(Stream[IO[StorageQueueEvent]]()) {
-      (stream, action) => archive.update(action) ++ stream
-    }.sequence
+    syncPlan.actions
+      .zipWithIndex
+      .foldLeft(Stream[IO[StorageQueueEvent]]()) {
+        (stream, indexedAction) => archive.update(indexedAction) ++ stream
+      }.sequence
 }
 
 object Program extends Program

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -52,6 +52,7 @@ trait Program {
                            (implicit l: Logger): IO[Stream[StorageQueueEvent]] =
     syncPlan.actions
       .zipWithIndex
+      .reverse
       .foldLeft(Stream[IO[StorageQueueEvent]]()) {
         (stream, indexedAction) => archive.update(indexedAction) ++ stream
       }.sequence

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -16,8 +16,8 @@ trait Program {
         ExitCode.Success
     } else {
       for {
-        actions <- Synchronise.createPlan(defaultStorageService, defaultHashService, cliOptions).valueOrF(handleErrors)
-        events <- handleActions(UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions)), actions)
+        syncPlan <- Synchronise.createPlan(defaultStorageService, defaultHashService, cliOptions).valueOrF(handleErrors)
+        events <- handleActions(UnversionedMirrorArchive.default(defaultStorageService, ConfigQuery.batchMode(cliOptions)), syncPlan)
         _ <- defaultStorageService.shutdown
         _ <- SyncLogging.logRunFinished(events)
       } yield ExitCode.Success

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -24,19 +24,19 @@ trait Program {
     }
   }
 
-  private def handleErrors(implicit logger: Logger): List[String] => IO[Stream[Action]] = {
+  private def handleErrors(implicit logger: Logger): List[String] => IO[SyncPlan] = {
     errors => {
       for {
         _ <- logger.error("There were errors:")
         _ <- errors.map(error => logger.error(s" - $error")).sequence
-      } yield Stream()
+      } yield SyncPlan()
     }
   }
 
   private def handleActions(archive: ThorpArchive,
-                            actions: Stream[Action])
+                            actions: SyncPlan)
                            (implicit l: Logger): IO[Stream[StorageQueueEvent]] =
-    actions.foldLeft(Stream[IO[StorageQueueEvent]]()) {
+    actions.actions.foldLeft(Stream[IO[StorageQueueEvent]]()) {
       (stream, action) => archive.update(action) ++ stream
     }.sequence
 }

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
@@ -1,0 +1,7 @@
+package net.kemitix.thorp.cli
+
+import org.scalatest.FunSpec
+
+class ProgramTest extends FunSpec {
+
+}

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
@@ -5,7 +5,7 @@ import java.io.File
 import cats.data.EitherT
 import cats.effect.IO
 import net.kemitix.thorp.core.Action.{ToCopy, ToDelete, ToUpload}
-import net.kemitix.thorp.core.{Action, ConfigOption, ConfigOptions, Resource, SyncPlan, PlanBuilder, ThorpArchive}
+import net.kemitix.thorp.core._
 import net.kemitix.thorp.domain.{Bucket, LocalFile, Logger, MD5Hash, RemoteKey, StorageQueueEvent}
 import net.kemitix.thorp.storage.api.{HashService, StorageService}
 import org.scalatest.FunSpec

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
@@ -1,7 +1,62 @@
 package net.kemitix.thorp.cli
 
+import java.io.File
+
+import cats.data.EitherT
+import cats.effect.IO
+import net.kemitix.thorp.core.Action.{ToCopy, ToDelete, ToUpload}
+import net.kemitix.thorp.core.{Action, ConfigOption, ConfigOptions, Resource, SyncPlan, PlanBuilder, ThorpArchive}
+import net.kemitix.thorp.domain.{Bucket, LocalFile, Logger, MD5Hash, RemoteKey, StorageQueueEvent}
+import net.kemitix.thorp.storage.api.{HashService, StorageService}
 import org.scalatest.FunSpec
 
 class ProgramTest extends FunSpec {
 
+  val source: File = Resource(this, ".")
+  val bucket: Bucket = Bucket("aBucket")
+  val hash: MD5Hash = MD5Hash("aHash")
+  val copyAction: Action = ToCopy(bucket, RemoteKey("copy-me"), hash, RemoteKey("overwrite-me"))
+  val uploadAction: Action = ToUpload(bucket, LocalFile.resolve("aFile", Map(), source, _ => RemoteKey("upload-me")))
+  val deleteAction: Action = ToDelete(bucket, RemoteKey("delete-me"))
+
+  val configOptions: ConfigOptions = ConfigOptions(options = List(
+    ConfigOption.IgnoreGlobalOptions,
+    ConfigOption.IgnoreUserOptions
+  ))
+
+  describe("upload, copy and delete actions in plan") {
+    val archive = TestProgram.thorpArchive
+    it("should be handled in correct order") {
+      val expected = List(copyAction, uploadAction, deleteAction)
+      TestProgram.run(configOptions).unsafeRunSync
+      val result = archive.actions
+      assertResult(expected)(result)
+    }
+  }
+
+  object TestProgram extends Program with TestPlanBuilder {
+    val thorpArchive: ActionCaptureArchive = new ActionCaptureArchive
+    override def thorpArchive(cliOptions: ConfigOptions, syncPlan: SyncPlan): IO[ThorpArchive] =
+      IO.pure(thorpArchive)
+  }
+
+  trait TestPlanBuilder extends PlanBuilder {
+    override def createPlan(storageService: StorageService,
+                            hashService: HashService,
+                            configOptions: ConfigOptions)
+                           (implicit l: Logger): EitherT[IO, List[String], SyncPlan] = {
+      EitherT.right(IO(SyncPlan(Stream(copyAction, uploadAction, deleteAction))))
+    }
+  }
+
+  class ActionCaptureArchive extends ThorpArchive {
+    var actions: List[Action] = List[Action]()
+    override def update(indexedAction: (Action, Int))(implicit l: Logger): Stream[IO[StorageQueueEvent]] = {
+      val (action, _) = indexedAction
+      actions = action :: actions
+      Stream()
+    }
+  }
+
 }
+

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
@@ -15,9 +15,9 @@ class ProgramTest extends FunSpec {
   val source: File = Resource(this, ".")
   val bucket: Bucket = Bucket("aBucket")
   val hash: MD5Hash = MD5Hash("aHash")
-  val copyAction: Action = ToCopy(bucket, RemoteKey("copy-me"), hash, RemoteKey("overwrite-me"))
-  val uploadAction: Action = ToUpload(bucket, LocalFile.resolve("aFile", Map(), source, _ => RemoteKey("upload-me")))
-  val deleteAction: Action = ToDelete(bucket, RemoteKey("delete-me"))
+  val copyAction: Action = ToCopy(bucket, RemoteKey("copy-me"), hash, RemoteKey("overwrite-me"), 17L)
+  val uploadAction: Action = ToUpload(bucket, LocalFile.resolve("aFile", Map(), source, _ => RemoteKey("upload-me")), 23L)
+  val deleteAction: Action = ToDelete(bucket, RemoteKey("delete-me"), 0L)
 
   val configOptions: ConfigOptions = ConfigOptions(options = List(
     ConfigOption.IgnoreGlobalOptions,
@@ -51,8 +51,10 @@ class ProgramTest extends FunSpec {
 
   class ActionCaptureArchive extends ThorpArchive {
     var actions: List[Action] = List[Action]()
-    override def update(indexedAction: (Action, Int))(implicit l: Logger): Stream[IO[StorageQueueEvent]] = {
-      val (action, _) = indexedAction
+    override def update(index: Int,
+                        action: Action,
+                        totalBytesSoFar: Long)
+                       (implicit l: Logger): Stream[IO[StorageQueueEvent]] = {
       actions = action :: actions
       Stream()
     }

--- a/core/src/main/scala/net/kemitix/thorp/core/Action.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Action.scala
@@ -4,21 +4,26 @@ import net.kemitix.thorp.domain.{Bucket, LocalFile, MD5Hash, RemoteKey}
 
 sealed trait Action {
   def bucket: Bucket
+  def size: Long
 }
 object Action {
 
   final case class DoNothing(bucket: Bucket,
-                             remoteKey: RemoteKey) extends Action
+                             remoteKey: RemoteKey,
+                             size: Long) extends Action
 
   final case class ToUpload(bucket: Bucket,
-                            localFile: LocalFile) extends Action
+                            localFile: LocalFile,
+                            size: Long) extends Action
 
   final case class ToCopy(bucket: Bucket,
                           sourceKey: RemoteKey,
                           hash: MD5Hash,
-                          targetKey: RemoteKey) extends Action
+                          targetKey: RemoteKey,
+                          size: Long) extends Action
 
   final case class ToDelete(bucket: Bucket,
-                            remoteKey: RemoteKey) extends Action
+                            remoteKey: RemoteKey,
+                            size: Long) extends Action
 
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
@@ -40,12 +40,12 @@ object ActionGenerator {
   private def doNothing(bucket: Bucket,
                         remoteKey: RemoteKey) =
     Stream(
-      DoNothing(bucket, remoteKey))
+      DoNothing(bucket, remoteKey, 0L))
 
   private def uploadFile(bucket: Bucket,
                          localFile: LocalFile) =
     Stream(
-      ToUpload(bucket, localFile))
+      ToUpload(bucket, localFile, localFile.file.length))
 
   private def copyFile(bucket: Bucket,
                        localFile: LocalFile,
@@ -54,7 +54,7 @@ object ActionGenerator {
     headOption.toStream.map { remoteMetaData =>
       val sourceKey = remoteMetaData.remoteKey
       val hash = remoteMetaData.hash
-      ToCopy(bucket, sourceKey, hash, localFile.remoteKey)
+      ToCopy(bucket, sourceKey, hash, localFile.remoteKey, localFile.file.length)
     }
   }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/LocalFileStream.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/LocalFileStream.scala
@@ -48,13 +48,16 @@ object LocalFileStream {
     loop(file)
   }
 
-  private def localFile(hashService: HashService, file: File)(implicit l: Logger, c: Config) = {
+  private def localFile(hashService: HashService,
+                        file: File)
+                       (implicit l: Logger, c: Config) = {
     for {
       hash <- hashService.hashLocalObject(file)
     } yield
       LocalFiles(
         localFiles = Stream(domain.LocalFile(file, c.source, hash, generateKey(c.source, c.prefix)(file))),
-        count = 1)
+        count = 1,
+        totalSizeBytes = file.length)
   }
 
   //TODO: Change this to return an Either[IllegalArgumentException, Array[File]]

--- a/core/src/main/scala/net/kemitix/thorp/core/LocalFileStream.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/LocalFileStream.scala
@@ -51,7 +51,10 @@ object LocalFileStream {
   private def localFile(hashService: HashService, file: File)(implicit l: Logger, c: Config) = {
     for {
       hash <- hashService.hashLocalObject(file)
-    } yield LocalFiles(Stream(domain.LocalFile(file, c.source, hash, generateKey(c.source, c.prefix)(file))))
+    } yield
+      LocalFiles(
+        localFiles = Stream(domain.LocalFile(file, c.source, hash, generateKey(c.source, c.prefix)(file))),
+        count = 1)
   }
 
   //TODO: Change this to return an Either[IllegalArgumentException, Array[File]]

--- a/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
@@ -2,9 +2,11 @@ package net.kemitix.thorp.core
 
 import net.kemitix.thorp.domain.LocalFile
 
-case class LocalFiles(localFiles: Stream[LocalFile] = Stream()) {
+case class LocalFiles(localFiles: Stream[LocalFile] = Stream(),
+                      count: Long = 0) {
   def ++(append: LocalFiles): LocalFiles =
-    copy(localFiles = localFiles ++ append.localFiles)
+    copy(localFiles = localFiles ++ append.localFiles,
+      count = count + append.count)
 
 }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
@@ -1,0 +1,10 @@
+package net.kemitix.thorp.core
+
+import net.kemitix.thorp.domain.LocalFile
+
+case class LocalFiles(localFiles: Stream[LocalFile] = Stream()) {
+  def ++(append: LocalFiles): LocalFiles =
+    copy(localFiles = localFiles ++ append.localFiles)
+
+}
+

--- a/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
@@ -3,10 +3,12 @@ package net.kemitix.thorp.core
 import net.kemitix.thorp.domain.LocalFile
 
 case class LocalFiles(localFiles: Stream[LocalFile] = Stream(),
-                      count: Long = 0) {
+                      count: Long = 0,
+                      totalSizeBytes: Long = 0) {
   def ++(append: LocalFiles): LocalFiles =
     copy(localFiles = localFiles ++ append.localFiles,
-      count = count + append.count)
+      count = count + append.count,
+      totalSizeBytes = totalSizeBytes + append.totalSizeBytes)
 
 }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
@@ -84,8 +84,8 @@ trait PlanBuilder {
 
   private def createActionFromRemoteKey(rk: RemoteKey)
                                        (implicit c: Config) =
-    if (rk.isMissingLocally(c.source, c.prefix)) Action.ToDelete(c.bucket, rk)
-    else DoNothing(c.bucket, rk)
+    if (rk.isMissingLocally(c.source, c.prefix)) Action.ToDelete(c.bucket, rk, 0L)
+    else DoNothing(c.bucket, rk, 0L)
 
 }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
@@ -7,7 +7,7 @@ import net.kemitix.thorp.core.Action.DoNothing
 import net.kemitix.thorp.domain._
 import net.kemitix.thorp.storage.api.{HashService, StorageService}
 
-trait Synchronise {
+trait PlanBuilder {
 
   def createPlan(storageService: StorageService,
             hashService: HashService,
@@ -89,4 +89,4 @@ trait Synchronise {
 
 }
 
-object Synchronise extends Synchronise
+object PlanBuilder extends PlanBuilder

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
@@ -1,5 +1,5 @@
 package net.kemitix.thorp.core
 
-case class SyncPlan(actions: Stream[Action] = Stream()) {
-
-}
+case class SyncPlan(actions: Stream[Action] = Stream(),
+                    count: Long = 0L,
+                    totalSizeBytes: Long = 0L)

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
@@ -1,4 +1,6 @@
 package net.kemitix.thorp.core
 
+import net.kemitix.thorp.domain.SyncTotals
+
 case class SyncPlan(actions: Stream[Action] = Stream(),
                     syncTotals: SyncTotals = SyncTotals())

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
@@ -1,0 +1,5 @@
+package net.kemitix.thorp.core
+
+case class SyncPlan(actions: Stream[Action] = Stream()) {
+
+}

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
@@ -1,5 +1,4 @@
 package net.kemitix.thorp.core
 
 case class SyncPlan(actions: Stream[Action] = Stream(),
-                    count: Long = 0L,
-                    totalSizeBytes: Long = 0L)
+                    syncTotals: SyncTotals = SyncTotals())

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncTotals.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncTotals.scala
@@ -1,0 +1,4 @@
+package net.kemitix.thorp.core
+
+case class SyncTotals(count: Long = 0L,
+                      totalSizeBytes: Long = 0L)

--- a/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
@@ -31,7 +31,7 @@ trait Synchronise {
     for {
       _ <- EitherT.liftF(SyncLogging.logRunStart(c.bucket, c.prefix, c.source))
       actions <- gatherMetadata(storageService, hashService)
-        .swap.map(error => List(error)).swap
+        .leftMap(error => List(error))
         .map {
           case (remoteData, localData) =>
             (actionsForLocalFiles(localData, remoteData) ++

--- a/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
@@ -58,7 +58,8 @@ trait Synchronise {
                                   (implicit c: Config) =
     remoteData.byKey.keys.foldLeft(Stream[Action]())((acc, rk) => createActionFromRemoteKey(rk) #:: acc)
 
-  private def fetchRemoteData(storageService: StorageService)(implicit c: Config) =
+  private def fetchRemoteData(storageService: StorageService)
+                             (implicit c: Config, l: Logger) =
     storageService.listObjects(c.bucket, c.prefix)
 
   private def findLocalFiles(hashService: HashService)

--- a/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
@@ -44,15 +44,15 @@ trait Synchronise {
   private def gatherMetadata(storageService: StorageService,
                              hashService: HashService)
                             (implicit l: Logger,
-                             c: Config): EitherT[IO, String, (S3ObjectsData, Stream[LocalFile])] =
+                             c: Config): EitherT[IO, String, (S3ObjectsData, LocalFiles)] =
     for {
       remoteData <- fetchRemoteData(storageService)
       localData <- EitherT.liftF(findLocalFiles(hashService))
     } yield (remoteData, localData)
 
-  private def actionsForLocalFiles(localData: Stream[LocalFile], remoteData: S3ObjectsData)
+  private def actionsForLocalFiles(localData: LocalFiles, remoteData: S3ObjectsData)
                                   (implicit c: Config) =
-    localData.foldLeft(Stream[Action]())((acc, lf) => createActionFromLocalFile(lf, remoteData) ++ acc)
+    localData.localFiles.foldLeft(Stream[Action]())((acc, lf) => createActionFromLocalFile(lf, remoteData) ++ acc)
 
   private def actionsForRemoteKeys(remoteData: S3ObjectsData)
                                   (implicit c: Config) =

--- a/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
@@ -61,8 +61,12 @@ trait Synchronise {
   private def fetchRemoteData(storageService: StorageService)(implicit c: Config) =
     storageService.listObjects(c.bucket, c.prefix)
 
-  private def findLocalFiles(hashService: HashService)(implicit config: Config, l: Logger) =
-    LocalFileStream.findFiles(config.source, hashService)
+  private def findLocalFiles(hashService: HashService)
+                            (implicit config: Config, l: Logger) =
+    for {
+      _ <- SyncLogging.logFileScan
+      localFiles <- LocalFileStream.findFiles(config.source, hashService)
+    } yield localFiles
 
   private def createActionFromLocalFile(lf: LocalFile, remoteData: S3ObjectsData)
                                        (implicit c: Config) =

--- a/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
@@ -33,9 +33,9 @@ trait Synchronise {
           .filter(removeDoNothing)
       SyncPlan(
         actions = actions,
-        count = localData.count,
-        totalSizeBytes = localData.totalSizeBytes
-      )
+        syncTotals = SyncTotals(
+          count = localData.count,
+          totalSizeBytes = localData.totalSizeBytes))
     }
   }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Synchronise.scala
@@ -26,10 +26,17 @@ trait Synchronise {
   }
 
   def assemblePlan(implicit c: Config): ((S3ObjectsData, LocalFiles)) => SyncPlan = {
-    case (remoteData, localData) =>
-      SyncPlan(actions = (actionsForLocalFiles(localData, remoteData) ++
-        actionsForRemoteKeys(remoteData))
-        .filter(removeDoNothing))
+    case (remoteData, localData) => {
+      val actions =
+        (actionsForLocalFiles(localData, remoteData) ++
+          actionsForRemoteKeys(remoteData))
+          .filter(removeDoNothing)
+      SyncPlan(
+        actions = actions,
+        count = localData.count,
+        totalSizeBytes = localData.totalSizeBytes
+      )
+    }
   }
 
   def useValidConfig(storageService: StorageService,

--- a/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
@@ -5,7 +5,7 @@ import net.kemitix.thorp.domain.{LocalFile, Logger, StorageQueueEvent}
 
 trait ThorpArchive {
 
-  def update(action: Action)(implicit l: Logger): Stream[IO[StorageQueueEvent]]
+  def update(indexedAction: (Action, Int))(implicit l: Logger): Stream[IO[StorageQueueEvent]]
 
   def fileUploaded(localFile: LocalFile,
                    batchMode: Boolean)

--- a/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
@@ -5,7 +5,10 @@ import net.kemitix.thorp.domain.{LocalFile, Logger, StorageQueueEvent}
 
 trait ThorpArchive {
 
-  def update(indexedAction: (Action, Int))(implicit l: Logger): Stream[IO[StorageQueueEvent]]
+  def update(index: Int,
+             action: Action,
+             totalBytesSoFar: Long)
+            (implicit l: Logger): Stream[IO[StorageQueueEvent]]
 
   def fileUploaded(localFile: LocalFile,
                    batchMode: Boolean)

--- a/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
@@ -15,7 +15,7 @@ case class UnversionedMirrorArchive(storageService: StorageService,
       indexedAction match {
         case (ToUpload(bucket, localFile), index) =>
           for {
-            event <- storageService.upload(localFile, bucket, batchMode, new UploadEventListener(localFile), 1)
+            event <- storageService.upload(localFile, bucket, batchMode, new UploadEventListener(localFile, index, syncTotals), 1)
             _ <- fileUploaded(localFile, batchMode)
           } yield event
         case (ToCopy(bucket, sourceKey, hash, targetKey), index) =>

--- a/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
@@ -8,7 +8,7 @@ import net.kemitix.thorp.storage.api.StorageService
 
 case class UnversionedMirrorArchive(storageService: StorageService,
                                     batchMode: Boolean,
-                                    syncPlan: SyncPlan) extends ThorpArchive {
+                                    syncTotals: SyncTotals) extends ThorpArchive {
   override def update(indexedAction: (Action, Int))
                      (implicit l: Logger): Stream[IO[StorageQueueEvent]] =
     Stream(
@@ -35,6 +35,6 @@ case class UnversionedMirrorArchive(storageService: StorageService,
 object UnversionedMirrorArchive {
   def default(storageService: StorageService,
               batchMode: Boolean,
-              syncPlan: SyncPlan): ThorpArchive =
-    new UnversionedMirrorArchive(storageService, batchMode, syncPlan)
+              syncTotals: SyncTotals): ThorpArchive =
+    new UnversionedMirrorArchive(storageService, batchMode, syncTotals)
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
@@ -3,7 +3,7 @@ package net.kemitix.thorp.core
 import cats.effect.IO
 import net.kemitix.thorp.core.Action.{DoNothing, ToCopy, ToDelete, ToUpload}
 import net.kemitix.thorp.domain.StorageQueueEvent.DoNothingQueueEvent
-import net.kemitix.thorp.domain.{Logger, StorageQueueEvent, UploadEventListener}
+import net.kemitix.thorp.domain.{Logger, StorageQueueEvent, SyncTotals, UploadEventListener}
 import net.kemitix.thorp.storage.api.StorageService
 
 case class UnversionedMirrorArchive(storageService: StorageService,

--- a/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
@@ -3,11 +3,12 @@ package net.kemitix.thorp.core
 import cats.effect.IO
 import net.kemitix.thorp.core.Action.{DoNothing, ToCopy, ToDelete, ToUpload}
 import net.kemitix.thorp.domain.StorageQueueEvent.DoNothingQueueEvent
-import net.kemitix.thorp.domain.{LocalFile, Logger, StorageQueueEvent, UploadEventListener}
+import net.kemitix.thorp.domain.{Logger, StorageQueueEvent, UploadEventListener}
 import net.kemitix.thorp.storage.api.StorageService
 
 case class UnversionedMirrorArchive(storageService: StorageService,
-                                    batchMode: Boolean) extends ThorpArchive {
+                                    batchMode: Boolean,
+                                    syncPlan: SyncPlan) extends ThorpArchive {
   override def update(indexedAction: (Action, Int))
                      (implicit l: Logger): Stream[IO[StorageQueueEvent]] =
     Stream(
@@ -33,6 +34,7 @@ case class UnversionedMirrorArchive(storageService: StorageService,
 
 object UnversionedMirrorArchive {
   def default(storageService: StorageService,
-              batchMode: Boolean): ThorpArchive =
-    new UnversionedMirrorArchive(storageService, batchMode)
+              batchMode: Boolean,
+              syncPlan: SyncPlan): ThorpArchive =
+    new UnversionedMirrorArchive(storageService, batchMode, syncPlan)
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
@@ -29,7 +29,7 @@ class ActionGeneratorSuite
           matchByKey = Some(theRemoteMetadata) // remote exists
           )
         it("do nothing") {
-          val expected = List(DoNothing(bucket, theFile.remoteKey))
+          val expected = List(DoNothing(bucket, theFile.remoteKey, theFile.file.length))
           val result = invoke(input)
           assertResult(expected)(result)
         }
@@ -44,7 +44,7 @@ class ActionGeneratorSuite
           matchByHash = Set(otherRemoteMetadata), // other matches
           matchByKey = None) // remote is missing
         it("copy from other key") {
-          val expected = List(ToCopy(bucket, otherRemoteKey, theHash, theRemoteKey)) // copy
+          val expected = List(ToCopy(bucket, otherRemoteKey, theHash, theRemoteKey, theFile.file.length)) // copy
           val result = invoke(input)
           assertResult(expected)(result)
         }
@@ -56,7 +56,7 @@ class ActionGeneratorSuite
           matchByHash = Set.empty, // other no matches
           matchByKey = None) // remote is missing
         it("upload") {
-          val expected = List(ToUpload(bucket, theFile)) // upload
+          val expected = List(ToUpload(bucket, theFile, theFile.file.length)) // upload
           val result = invoke(input)
           assertResult(expected)(result)
         }
@@ -75,7 +75,7 @@ class ActionGeneratorSuite
           matchByHash = Set(otherRemoteMetadata), // other matches
           matchByKey = Some(oldRemoteMetadata)) // remote exists
         it("copy from other key") {
-          val expected = List(ToCopy(bucket, otherRemoteKey, theHash, theRemoteKey)) // copy
+          val expected = List(ToCopy(bucket, otherRemoteKey, theHash, theRemoteKey, theFile.file.length)) // copy
           val result = invoke(input)
           assertResult(expected)(result)
         }
@@ -91,7 +91,7 @@ class ActionGeneratorSuite
           matchByKey = Some(theRemoteMetadata) // remote exists
         )
         it("upload") {
-          val expected = List(ToUpload(bucket, theFile)) // upload
+          val expected = List(ToUpload(bucket, theFile, theFile.file.length)) // upload
           val result = invoke(input)
           assertResult(expected)(result)
         }

--- a/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
@@ -31,6 +31,10 @@ class LocalFileStreamSuite extends FunSpec {
       val result = invoke.count
       assertResult(2)(result)
     }
+    it("should sum the size of all files") {
+      val result = invoke.totalSizeBytes
+      assertResult(113)(result)
+    }
   }
 
   private def invoke = {

--- a/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
@@ -27,6 +27,10 @@ class LocalFileStreamSuite extends FunSpec {
           .map { x: LocalFile => x.relative.toString }
       assertResult(Set("subdir/leaf-file", "root-file"))(result)
     }
+    it("should count all files") {
+      val result = invoke.count
+      assertResult(2)(result)
+    }
   }
 
   private def invoke = {

--- a/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
@@ -23,9 +23,13 @@ class LocalFileStreamSuite extends FunSpec {
   describe("findFiles") {
     it("should find all files") {
       val result: Set[String] =
-        LocalFileStream.findFiles(uploadResource, hashService).unsafeRunSync.toSet
+        invoke.localFiles.toSet
           .map { x: LocalFile => x.relative.toString }
       assertResult(Set("subdir/leaf-file", "root-file"))(result)
     }
+  }
+
+  private def invoke = {
+    LocalFileStream.findFiles(uploadResource, hashService).unsafeRunSync
   }
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -51,7 +51,7 @@ class SyncSuite
   def invokeSubject(storageService: StorageService,
                               hashService: HashService,
                               configOptions: ConfigOptions): Either[List[String], SyncPlan] = {
-    Synchronise.createPlan(storageService, hashService, configOptions).value.unsafeRunSync
+    PlanBuilder.createPlan(storageService, hashService, configOptions).value.unsafeRunSync
   }
 
   def invokeSubjectForActions(storageService: StorageService,

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -67,8 +67,8 @@ class SyncSuite
       byKey = Map()))
     it("uploads all files") {
       val expected = Right(Set(
-        ToUpload(testBucket, rootFile),
-        ToUpload(testBucket, leafFile)))
+        ToUpload(testBucket, rootFile, rootFile.file.length),
+        ToUpload(testBucket, leafFile, leafFile.file.length)))
       val result = invokeSubjectForActions(storageService, hashService, configOptions)
       assertResult(expected)(result.map(_.toSet))
     }
@@ -107,8 +107,8 @@ class SyncSuite
     val storageService = new RecordingStorageService(testBucket, s3ObjectsData)
     it("copies the file and deletes the original") {
       val expected = Stream(
-        ToCopy(testBucket,  sourceKey, Root.hash, targetKey),
-        ToDelete(testBucket, sourceKey)
+        ToCopy(testBucket,  sourceKey, Root.hash, targetKey, rootFile.file.length),
+        ToDelete(testBucket, sourceKey, 0L)
       )
       val result = invokeSubjectForActions(storageService, hashService, configOptions)
       assert(result.isRight)
@@ -135,7 +135,7 @@ class SyncSuite
     val storageService = new RecordingStorageService(testBucket, s3ObjectsData)
     it("deleted key") {
       val expected = Stream(
-        ToDelete(testBucket, deletedKey)
+        ToDelete(testBucket, deletedKey, 0L)
       )
       val result = invokeSubjectForActions(storageService,hashService, configOptions)
       assert(result.isRight)

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -157,7 +157,8 @@ class SyncSuite
     extends StorageService {
 
     override def listObjects(bucket: Bucket,
-                             prefix: RemoteKey): EitherT[IO, String, S3ObjectsData] =
+                             prefix: RemoteKey)
+                            (implicit l: Logger): EitherT[IO, String, S3ObjectsData] =
       EitherT.liftF(IO.pure(s3ObjectsData))
 
     override def upload(localFile: LocalFile,

--- a/domain/src/main/scala/net/kemitix/thorp/domain/SyncTotals.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/SyncTotals.scala
@@ -1,4 +1,5 @@
 package net.kemitix.thorp.domain
 
 case class SyncTotals(count: Long = 0L,
-                      totalSizeBytes: Long = 0L)
+                      totalSizeBytes: Long = 0L,
+                      sizeUploadedBytes: Long = 0L)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/SyncTotals.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/SyncTotals.scala
@@ -1,4 +1,4 @@
-package net.kemitix.thorp.core
+package net.kemitix.thorp.domain
 
 case class SyncTotals(count: Long = 0L,
                       totalSizeBytes: Long = 0L)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
@@ -5,14 +5,15 @@ import net.kemitix.thorp.domain.UploadEventLogger.logRequestCycle
 
 class UploadEventListener(localFile: LocalFile,
                           index: Int,
-                          syncTotals: SyncTotals) {
+                          syncTotals: SyncTotals,
+                          totalBytesSoFar: Long) {
 
   var bytesTransferred = 0L
 
   def listener: UploadEvent => Unit = {
       case e: RequestEvent =>
         bytesTransferred += e.transferred
-        logRequestCycle(localFile, e, bytesTransferred, index, syncTotals)
-      case _ => ()
+        logRequestCycle(localFile, e, bytesTransferred, index, syncTotals, totalBytesSoFar)
+    case _ => ()
     }
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
@@ -3,15 +3,16 @@ package net.kemitix.thorp.domain
 import net.kemitix.thorp.domain.UploadEvent.RequestEvent
 import net.kemitix.thorp.domain.UploadEventLogger.logRequestCycle
 
-class UploadEventListener(localFile: LocalFile) {
+class UploadEventListener(localFile: LocalFile,
+                          index: Int,
+                          syncTotals: SyncTotals) {
 
   var bytesTransferred = 0L
 
-  def listener: UploadEvent => Unit =
-    {
+  def listener: UploadEvent => Unit = {
       case e: RequestEvent =>
         bytesTransferred += e.transferred
-        logRequestCycle(localFile, e, bytesTransferred)
+        logRequestCycle(localFile, e, bytesTransferred, index, syncTotals)
       case _ => ()
     }
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
@@ -12,7 +12,8 @@ trait UploadEventLogger {
                       event: RequestEvent,
                       bytesTransferred: Long,
                       index: Int,
-                      syncTotals: SyncTotals): Unit = {
+                      syncTotals: SyncTotals,
+                      totalBytesSoFar: Long): Unit = {
     val remoteKey = localFile.remoteKey.key
     val fileLength = localFile.file.length
     val statusHeight = 7
@@ -21,7 +22,7 @@ trait UploadEventLogger {
         s"${GREEN}Uploading:$RESET $remoteKey$eraseToEndOfScreen\n" +
           statusWithBar(" File", sizeInEnglish, bytesTransferred, fileLength) +
           statusWithBar("Files", l => l.toString, index, syncTotals.count) +
-          statusWithBar(" Size", sizeInEnglish, syncTotals.sizeUploadedBytes + bytesTransferred, syncTotals.totalSizeBytes) +
+          statusWithBar(" Size", sizeInEnglish, bytesTransferred + totalBytesSoFar, syncTotals.totalSizeBytes) +
           s"${Terminal.cursorPrevLine(statusHeight)}")
     } else
       println(s"${GREEN}Uploaded:$RESET $remoteKey$eraseToEndOfScreen")

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
@@ -10,7 +10,9 @@ trait UploadEventLogger {
 
   def logRequestCycle(localFile: LocalFile,
                       event: RequestEvent,
-                      bytesTransferred: Long): Unit = {
+                      bytesTransferred: Long,
+                      index: Int,
+                      syncTotals: SyncTotals): Unit = {
     val remoteKey = localFile.remoteKey.key
     val fileLength = localFile.file.length
     if (bytesTransferred < fileLength) {

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
@@ -16,15 +16,26 @@ trait UploadEventLogger {
     val remoteKey = localFile.remoteKey.key
     val fileLength = localFile.file.length
     if (bytesTransferred < fileLength) {
-      val bar = progressBar(bytesTransferred, fileLength.toDouble, Terminal.width)
-      val transferred = sizeInEnglish(bytesTransferred)
-      val fileSize = sizeInEnglish(fileLength)
-      val message = s"${GREEN}Uploaded $transferred of $fileSize $RESET: $remoteKey$eraseLineForward"
-      println(s"$message\n$bar${Terminal.cursorPrevLine() * 2}")
+      println(
+        s"${GREEN}Uploading:$RESET $remoteKey$eraseLineForward\n" +
+          statusWithBar(" File", sizeInEnglish, bytesTransferred, fileLength) +
+          statusWithBar("Files", l => l.toString, index, syncTotals.count) +
+          statusWithBar(" Size", sizeInEnglish, syncTotals.sizeUploadedBytes + bytesTransferred, syncTotals.totalSizeBytes) +
+          s"${Terminal.cursorPrevLine() * 7}")
     } else
       println(s"${GREEN}Uploaded:$RESET $remoteKey$eraseLineForward")
   }
 
+  private def statusWithBar(label: String,
+                            format: Long => String,
+                            current: Long,
+                            max: Long,
+                            pre: Long = 0): String = {
+    s"$GREEN$label:$RESET ${format(current)} of ${format(max)}" +
+      (if (pre > 0) s" (pre-synced ${format(pre)}"
+      else "") + s"$eraseLineForward\n" +
+      progressBar(current, max, Terminal.width)
+  }
 }
 
 object UploadEventLogger extends UploadEventLogger

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
@@ -33,7 +33,8 @@ trait UploadEventLogger {
                             current: Long,
                             max: Long,
                             pre: Long = 0): String = {
-    s"$GREEN$label:$RESET ${format(current)} of ${format(max)}" +
+    val percent = f"${(current * 100) / max}%2d"
+    s"$GREEN$label:$RESET ($percent%) ${format(current)} of ${format(max)}" +
       (if (pre > 0) s" (pre-synced ${format(pre)}"
       else "") + s"$eraseLineForward\n" +
       progressBar(current, max, Terminal.width)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala
@@ -15,15 +15,16 @@ trait UploadEventLogger {
                       syncTotals: SyncTotals): Unit = {
     val remoteKey = localFile.remoteKey.key
     val fileLength = localFile.file.length
+    val statusHeight = 7
     if (bytesTransferred < fileLength) {
       println(
-        s"${GREEN}Uploading:$RESET $remoteKey$eraseLineForward\n" +
+        s"${GREEN}Uploading:$RESET $remoteKey$eraseToEndOfScreen\n" +
           statusWithBar(" File", sizeInEnglish, bytesTransferred, fileLength) +
           statusWithBar("Files", l => l.toString, index, syncTotals.count) +
           statusWithBar(" Size", sizeInEnglish, syncTotals.sizeUploadedBytes + bytesTransferred, syncTotals.totalSizeBytes) +
-          s"${Terminal.cursorPrevLine() * 7}")
+          s"${Terminal.cursorPrevLine(statusHeight)}")
     } else
-      println(s"${GREEN}Uploaded:$RESET $remoteKey$eraseLineForward")
+      println(s"${GREEN}Uploaded:$RESET $remoteKey$eraseToEndOfScreen")
   }
 
   private def statusWithBar(label: String,

--- a/storage-api/src/main/scala/net/kemitix/thorp/storage/api/StorageService.scala
+++ b/storage-api/src/main/scala/net/kemitix/thorp/storage/api/StorageService.scala
@@ -9,7 +9,8 @@ trait StorageService {
   def shutdown: IO[StorageQueueEvent]
 
   def listObjects(bucket: Bucket,
-                  prefix: RemoteKey): EitherT[IO, String, S3ObjectsData]
+                  prefix: RemoteKey)
+                 (implicit l: Logger): EitherT[IO, String, S3ObjectsData]
 
   def upload(localFile: LocalFile,
              bucket: Bucket,

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Lister.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Lister.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ListObjectsV2Request, S3ObjectSummary}
 import net.kemitix.thorp.domain
-import net.kemitix.thorp.domain.{Bucket, RemoteKey, S3ObjectsData}
+import net.kemitix.thorp.domain.{Bucket, Logger, RemoteKey, S3ObjectsData}
 import net.kemitix.thorp.storage.aws.S3ObjectsByHash.byHash
 import net.kemitix.thorp.storage.aws.S3ObjectsByKey.byKey
 
@@ -14,11 +14,12 @@ import scala.util.Try
 
 class Lister(amazonS3: AmazonS3) {
 
-  def listObjects(bucket: Bucket,
-                  prefix: RemoteKey): EitherT[IO, String, S3ObjectsData] = {
+  private type Token = String
+  private type Batch = (Stream[S3ObjectSummary], Option[Token])
 
-    type Token = String
-    type Batch = (Stream[S3ObjectSummary], Option[Token])
+  def listObjects(bucket: Bucket,
+                  prefix: RemoteKey)
+                 (implicit l: Logger): EitherT[IO, String, S3ObjectsData] = {
 
     val requestMore = (token:Token) => new ListObjectsV2Request()
       .withBucketName(bucket.name)
@@ -28,15 +29,10 @@ class Lister(amazonS3: AmazonS3) {
     def fetchBatch: ListObjectsV2Request => EitherT[IO, String, Batch] =
       request =>
         EitherT {
-          IO.pure {
-            Try(amazonS3.listObjectsV2(request))
-              .map { result =>
-                val more: Option[Token] =
-                  if (result.isTruncated) Some(result.getNextContinuationToken)
-                  else None
-                (result.getObjectSummaries.asScala.toStream, more)
-              }.toEither.swap.map(e => e.getMessage).swap
-          }
+          for {
+            _ <- l.info("Fetching remote summaries...")
+            batch <- tryFetchBatch(request)
+          } yield batch
         }
 
     def fetchMore(more: Option[Token]): EitherT[IO, String, Stream[S3ObjectSummary]] = {
@@ -60,4 +56,15 @@ class Lister(amazonS3: AmazonS3) {
     } yield domain.S3ObjectsData(byHash(summaries), byKey(summaries))
   }
 
+  private def tryFetchBatch(request: ListObjectsV2Request): IO[Either[String, (Stream[S3ObjectSummary], Option[Token])]] = {
+    IO {
+      Try(amazonS3.listObjectsV2(request))
+        .map { result =>
+          val more: Option[Token] =
+            if (result.isTruncated) Some(result.getNextContinuationToken)
+            else None
+          (result.getObjectSummaries.asScala.toStream, more)
+        }.toEither.swap.map(e => e.getMessage).swap
+    }
+  }
 }

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Lister.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Lister.scala
@@ -21,19 +21,18 @@ class Lister(amazonS3: AmazonS3) {
                   prefix: RemoteKey)
                  (implicit l: Logger): EitherT[IO, String, S3ObjectsData] = {
 
-    val requestMore = (token:Token) => new ListObjectsV2Request()
+    val requestMore = (token: Token) => new ListObjectsV2Request()
       .withBucketName(bucket.name)
       .withPrefix(prefix.key)
       .withContinuationToken(token)
 
     def fetchBatch: ListObjectsV2Request => EitherT[IO, String, Batch] =
-      request =>
-        EitherT {
-          for {
-            _ <- l.info("Fetching remote summaries...")
-            batch <- tryFetchBatch(request)
-          } yield batch
-        }
+      request => EitherT {
+        for {
+          _ <- ListerLogger.logFetchBatch
+          batch <- tryFetchBatch(request)
+        } yield batch
+      }
 
     def fetchMore(more: Option[Token]): EitherT[IO, String, Stream[S3ObjectSummary]] = {
       more match {

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/ListerLogger.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/ListerLogger.scala
@@ -1,0 +1,9 @@
+package net.kemitix.thorp.storage.aws
+
+import cats.effect.IO
+import net.kemitix.thorp.domain.Logger
+
+trait ListerLogger {
+  def logFetchBatch(implicit l: Logger): IO[Unit] = l.info("Fetching remote summaries...")
+}
+object ListerLogger extends ListerLogger

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3StorageService.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3StorageService.scala
@@ -18,7 +18,8 @@ class S3StorageService(amazonS3Client: => AmazonS3,
   lazy val deleter = new Deleter(amazonS3Client)
 
   override def listObjects(bucket: Bucket,
-                           prefix: RemoteKey): EitherT[IO, String, S3ObjectsData] =
+                           prefix: RemoteKey)
+                          (implicit l: Logger): EitherT[IO, String, S3ObjectsData] =
     objectLister.listObjects(bucket, prefix)
 
   override def copy(bucket: Bucket,

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
@@ -116,7 +116,7 @@ class StorageServiceSuite
         LocalFile.resolve("root-file", md5HashMap(Root.hash), source, KeyGenerator.generateKey(source, prefix))
       val bucket = Bucket("a-bucket")
       val remoteKey = RemoteKey("prefix/root-file")
-      val uploadEventListener = new UploadEventListener(localFile, 1, SyncTotals())
+      val uploadEventListener = new UploadEventListener(localFile, 1, SyncTotals(), 0L)
 
       val upload = stub[Upload]
       (amazonS3TransferManager upload (_: PutObjectRequest)).when(*).returns(upload)

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
@@ -116,7 +116,7 @@ class StorageServiceSuite
         LocalFile.resolve("root-file", md5HashMap(Root.hash), source, KeyGenerator.generateKey(source, prefix))
       val bucket = Bucket("a-bucket")
       val remoteKey = RemoteKey("prefix/root-file")
-      val uploadEventListener = new UploadEventListener(localFile)
+      val uploadEventListener = new UploadEventListener(localFile, 1, SyncTotals())
 
       val upload = stub[Upload]
       (amazonS3TransferManager upload (_: PutObjectRequest)).when(*).returns(upload)

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
@@ -39,7 +39,7 @@ class UploaderSuite
       val returnedKey = RemoteKey("returned-key")
       val returnedHash = MD5Hash("returned-hash")
       val bigFile = LocalFile.resolve("small-file", md5HashMap(MD5Hash("the-hash")), source, fileToKey)
-      val uploadEventListener = new UploadEventListener(bigFile)
+      val uploadEventListener = new UploadEventListener(bigFile, 1, SyncTotals())
       val amazonS3 = mock[AmazonS3]
       val amazonS3TransferManager = TransferManagerBuilder.standard().withS3Client(amazonS3).build
       val uploader = new Uploader(amazonS3TransferManager)

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
@@ -39,7 +39,7 @@ class UploaderSuite
       val returnedKey = RemoteKey("returned-key")
       val returnedHash = MD5Hash("returned-hash")
       val bigFile = LocalFile.resolve("small-file", md5HashMap(MD5Hash("the-hash")), source, fileToKey)
-      val uploadEventListener = new UploadEventListener(bigFile, 1, SyncTotals())
+      val uploadEventListener = new UploadEventListener(bigFile, 1, SyncTotals(), 0L)
       val amazonS3 = mock[AmazonS3]
       val amazonS3TransferManager = TransferManagerBuilder.standard().withS3Client(amazonS3).build
       val uploader = new Uploader(amazonS3TransferManager)


### PR DESCRIPTION
e.g. 
```
Uploaded: previous/file.mp4
Uploaded 10Kb of 20Kb: path/to/file.mp4
[#########         ]
Uploaded: 10 of 40 files
[####              ]
Uploaded: 346Mb of 563Mb
[########          ]
```
* Include two line statuses for: numer of files to uploaded, size of files to uploaded, number of files copied, number of files deleted and time take/remaining
* Only include copied and deleted statuses if there are any such actions required