### PR TITLE
Sync more than one source directory into a single bucket/prefix

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,6 +12,7 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
    - Add a version command-line option (#99)
    - Add a batch mode (#85)
    - Display total size and progress for entire run (#94)
+   - Sync more than one source directory into a single bucket/prefile (#25)
 
 * [0.6.1] - 2019-07-03
 

--- a/README.org
+++ b/README.org
@@ -49,15 +49,18 @@ that can be written to a file.
   - User: ~ ~/.config/thorp.conf~
   - Source: ~${source}/.thorp.conf~
 
-Command line arguments override those in Source, which override those
-in User, which override those Global, which override any built-in
-config.
+  Command line arguments override those in Source, which override
+  those in User, which override those Global, which override any
+  built-in config.
 
-Built-in config consists of using the current working directory as the
-~source~.
+  When there is more than one source, only the first ".thorp.conf"
+  file found will be used.
 
-Note, that ~include~ and ~exclude~ are cumulative across all
-configuration files.
+  Built-in config consists of using the current working directory as
+  the ~source~.
+
+  Note, that ~include~ and ~exclude~ are cumulative across all
+  configuration files.
 
 * Behaviour
 

--- a/README.org
+++ b/README.org
@@ -32,6 +32,10 @@ If you don't provide a ~source~ the current diretory will be used.
 
 The ~--include~ and ~--exclude~ parameters can be used more than once.
 
+The ~--source~ parameter can be used more than once, in which case,
+all files in all sources will be consolidated into the same
+bucket/prefix.
+
 ** Batch mode
 
 Batch mode disable the ANSI console display and logs simple messages

--- a/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/ParseArgs.scala
@@ -20,6 +20,7 @@ object ParseArgs {
         .action((_, cos) => ConfigOption.BatchMode :: cos)
         .text("Enable batch-mode"),
       opt[String]('s', "source")
+        .unbounded()
         .action((str, cos) => ConfigOption.Source(Paths.get(str)) :: cos)
         .text("Source directory to sync to destination"),
       opt[String]('b', "bucket")

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
@@ -37,7 +37,7 @@ class ParseArgsTest extends FunSpec {
       it("should get multiple sources") {
         val expected = Set("path1", "path2").map(Paths.get(_))
         val configOptions = maybeConfigOptions.get
-        val result = ConfigQuery.sources(configOptions).toSet
+        val result = ConfigQuery.sources(configOptions).paths.toSet
         assertResult(expected)(result)
       }
     }

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
@@ -27,17 +27,14 @@ class ParseArgsTest extends FunSpec {
       it("should succeed") {pending}
     }
     describe("when there are multiple sources") {
-      val maybeConfigOptions = ParseArgs(List(
+      val args = List(
         "--source", "path1",
         "--source", "path2",
-        "--bucket", "bucket"))
-      it("should accept more than one source") {
-        assert(maybeConfigOptions.isDefined)
-      }
+        "--bucket", "bucket")
       it("should get multiple sources") {
-        val expected = Set("path1", "path2").map(Paths.get(_))
-        val configOptions = maybeConfigOptions.get
-        val result = ConfigQuery.sources(configOptions).paths.toSet
+        val expected = Some(Set("path1", "path2").map(Paths.get(_)))
+        val configOptions = ParseArgs(args)
+        val result = configOptions.map(ConfigQuery.sources(_).paths.toSet)
         assertResult(expected)(result)
       }
     }

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ParseArgsTest.scala
@@ -1,7 +1,9 @@
 package net.kemitix.thorp.cli
 
+import java.nio.file.Paths
+
 import net.kemitix.thorp.core.ConfigOption.Debug
-import net.kemitix.thorp.core.{ConfigOptions, Resource}
+import net.kemitix.thorp.core.{ConfigOptions, ConfigQuery, Resource}
 import org.scalatest.FunSpec
 
 import scala.util.Try
@@ -15,13 +17,29 @@ class ParseArgsTest extends FunSpec {
       ParseArgs(List("--source", path, "--bucket", "bucket"))
 
     describe("when source is a directory") {
-      val result = invokeWithSource(pathTo("."))
       it("should succeed") {
+        val result = invokeWithSource(pathTo("."))
         assert(result.isDefined)
       }
     }
     describe("when source is a relative path to a directory") {
+      val result = invokeWithSource(pathTo("."))
       it("should succeed") {pending}
+    }
+    describe("when there are multiple sources") {
+      val maybeConfigOptions = ParseArgs(List(
+        "--source", "path1",
+        "--source", "path2",
+        "--bucket", "bucket"))
+      it("should accept more than one source") {
+        assert(maybeConfigOptions.isDefined)
+      }
+      it("should get multiple sources") {
+        val expected = Set("path1", "path2").map(Paths.get(_))
+        val configOptions = maybeConfigOptions.get
+        val result = ConfigQuery.sources(configOptions).toSet
+        assertResult(expected)(result)
+      }
     }
   }
 

--- a/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
+++ b/cli/src/test/scala/net/kemitix/thorp/cli/ProgramTest.scala
@@ -1,22 +1,24 @@
 package net.kemitix.thorp.cli
 
 import java.io.File
+import java.nio.file.Path
 
 import cats.data.EitherT
 import cats.effect.IO
 import net.kemitix.thorp.core.Action.{ToCopy, ToDelete, ToUpload}
 import net.kemitix.thorp.core._
-import net.kemitix.thorp.domain.{Bucket, LocalFile, Logger, MD5Hash, RemoteKey, StorageQueueEvent}
+import net.kemitix.thorp.domain._
 import net.kemitix.thorp.storage.api.{HashService, StorageService}
 import org.scalatest.FunSpec
 
 class ProgramTest extends FunSpec {
 
   val source: File = Resource(this, ".")
+  val sourcePath: Path = source.toPath
   val bucket: Bucket = Bucket("aBucket")
   val hash: MD5Hash = MD5Hash("aHash")
   val copyAction: Action = ToCopy(bucket, RemoteKey("copy-me"), hash, RemoteKey("overwrite-me"), 17L)
-  val uploadAction: Action = ToUpload(bucket, LocalFile.resolve("aFile", Map(), source, _ => RemoteKey("upload-me")), 23L)
+  val uploadAction: Action = ToUpload(bucket, LocalFile.resolve("aFile", Map(), sourcePath, _ => RemoteKey("upload-me")), 23L)
   val deleteAction: Action = ToDelete(bucket, RemoteKey("delete-me"), 0L)
 
   val configOptions: ConfigOptions = ConfigOptions(options = List(

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
@@ -20,10 +20,18 @@ object ConfigOption {
     override def update(config: Config): Config = config.copy(sources = config.sources ++ path)
   }
   case class Bucket(name: String) extends ConfigOption {
-    override def update(config: Config): Config = config.copy(bucket = domain.Bucket(name))
+    override def update(config: Config): Config =
+      if (config.bucket.name.isEmpty)
+        config.copy(bucket = domain.Bucket(name))
+      else
+        config
   }
   case class Prefix(path: String) extends ConfigOption {
-    override def update(config: Config): Config = config.copy(prefix = RemoteKey(path))
+    override def update(config: Config): Config =
+      if (config.prefix.key.isEmpty)
+        config.copy(prefix = RemoteKey(path))
+      else
+        config
   }
   case class Include(pattern: String) extends ConfigOption {
     override def update(config: Config): Config = config.copy(filters = domain.Filter.Include(pattern) :: config.filters)

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
@@ -17,7 +17,7 @@ object ConfigOption {
     override def update(config: Config): Config = config.copy(batchMode = true)
   }
   case class Source(path: Path) extends ConfigOption {
-    override def update(config: Config): Config = config.copy(source = path)
+    override def update(config: Config): Config = config.copy(sources = config.sources ++ path)
   }
   case class Bucket(name: String) extends ConfigOption {
     override def update(config: Config): Config = config.copy(bucket = domain.Bucket(name))

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
@@ -17,7 +17,7 @@ object ConfigOption {
     override def update(config: Config): Config = config.copy(batchMode = true)
   }
   case class Source(path: Path) extends ConfigOption {
-    override def update(config: Config): Config = config.copy(source = path.toFile)
+    override def update(config: Config): Config = config.copy(source = path)
   }
   case class Bucket(name: String) extends ConfigOption {
     override def update(config: Config): Config = config.copy(bucket = domain.Bucket(name))

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigQuery.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigQuery.scala
@@ -1,6 +1,6 @@
 package net.kemitix.thorp.core
 
-import java.nio.file.Path
+import net.kemitix.thorp.domain.Sources
 
 trait ConfigQuery {
 
@@ -16,11 +16,13 @@ trait ConfigQuery {
   def ignoreGlobalOptions(configOptions: ConfigOptions): Boolean =
     configOptions contains ConfigOption.IgnoreGlobalOptions
 
-  def sources(configOptions: ConfigOptions): List[Path] =
-    configOptions.options.flatMap {
-      case s: ConfigOption.Source => Some(s)
+  def sources(configOptions: ConfigOptions): Sources = {
+    val paths = configOptions.options.flatMap( {
+      case ConfigOption.Source(sourcePath) => Some(sourcePath)
       case _ => None
-    }.map { s => s.path }
+    })
+    Sources(paths)
+  }
 }
 
 object ConfigQuery extends ConfigQuery

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigQuery.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigQuery.scala
@@ -1,5 +1,7 @@
 package net.kemitix.thorp.core
 
+import java.nio.file.Path
+
 trait ConfigQuery {
 
   def showVersion(configOptions: ConfigOptions): Boolean =
@@ -14,6 +16,11 @@ trait ConfigQuery {
   def ignoreGlobalOptions(configOptions: ConfigOptions): Boolean =
     configOptions contains ConfigOption.IgnoreGlobalOptions
 
+  def sources(configOptions: ConfigOptions): List[Path] =
+    configOptions.options.flatMap {
+      case s: ConfigOption.Source => Some(s)
+      case _ => None
+    }.map { s => s.path }
 }
 
 object ConfigQuery extends ConfigQuery

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
@@ -1,6 +1,6 @@
 package net.kemitix.thorp.core
 
-import java.io.File
+import java.nio.file.Path
 
 import cats.data.{NonEmptyChain, Validated, ValidatedNec}
 import cats.implicits._
@@ -10,15 +10,15 @@ sealed trait ConfigValidator {
 
   type ValidationResult[A] = ValidatedNec[ConfigValidation, A]
 
-  def validateSourceIsDirectory(source: File): ValidationResult[File] =
-    if(source.isDirectory) source.validNec
+  def validateSourceIsDirectory(source: Path): ValidationResult[Path] =
+    if(source.toFile.isDirectory) source.validNec
     else ConfigValidation.SourceIsNotADirectory.invalidNec
 
-  def validateSourceIsReadable(source: File): ValidationResult[File] =
-    if(source.canRead) source.validNec
+  def validateSourceIsReadable(source: Path): ValidationResult[Path] =
+    if(source.toFile.canRead) source.validNec
     else ConfigValidation.SourceIsNotReadable.invalidNec
 
-  def validateSource(source: File): ValidationResult[File] =
+  def validateSource(source: Path): ValidationResult[Path] =
     validateSourceIsDirectory(source).andThen(s => validateSourceIsReadable(s))
 
   def validateBucket(bucket: Bucket): ValidationResult[Bucket] =

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
@@ -19,16 +19,17 @@ sealed trait ConfigValidator {
     else ConfigValidation.SourceIsNotReadable.invalidNec
 
   def validateSource(source: Path): ValidationResult[Path] =
-    validateSourceIsDirectory(source).andThen(s => validateSourceIsReadable(s))
+    validateSourceIsDirectory(source)
+      .andThen(s =>
+        validateSourceIsReadable(s))
 
   def validateBucket(bucket: Bucket): ValidationResult[Bucket] =
     if (bucket.name.isEmpty) ConfigValidation.BucketNameIsMissing.invalidNec
     else bucket.validNec
 
   def validateSources(sources: Sources): ValidationResult[Sources] =
-    sources.paths.map { source =>
-      validateSource(source)
-    }.sequence
+    sources.paths
+      .map(validateSource).sequence
       .map(_ => sources)
 
   def validateConfig(config: Config): Validated[NonEmptyChain[ConfigValidation], Config] =

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigValidator.scala
@@ -4,7 +4,7 @@ import java.nio.file.Path
 
 import cats.data.{NonEmptyChain, Validated, ValidatedNec}
 import cats.implicits._
-import net.kemitix.thorp.domain.{Bucket, Config}
+import net.kemitix.thorp.domain.{Bucket, Config, Sources}
 
 sealed trait ConfigValidator {
 
@@ -25,9 +25,15 @@ sealed trait ConfigValidator {
     if (bucket.name.isEmpty) ConfigValidation.BucketNameIsMissing.invalidNec
     else bucket.validNec
 
+  def validateSources(sources: Sources): ValidationResult[Sources] =
+    sources.paths.map { source =>
+      validateSource(source)
+    }.sequence
+      .map(_ => sources)
+
   def validateConfig(config: Config): Validated[NonEmptyChain[ConfigValidation], Config] =
     (
-      validateSource(config.source),
+      validateSources(config.sources),
       validateBucket(config.bucket)
     ).mapN((_, _) => config)
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/KeyGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/KeyGenerator.scala
@@ -11,7 +11,9 @@ object KeyGenerator {
                  (path: Path): RemoteKey = {
     val source = sources.forPath(path)
     val relativePath = source.relativize(path.toAbsolutePath)
-    RemoteKey(s"${prefix.key}/$relativePath")
+    RemoteKey(List(prefix.key, relativePath.toString)
+        .filterNot(_.isEmpty)
+        .mkString("/"))
   }
 
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/KeyGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/KeyGenerator.scala
@@ -2,12 +2,14 @@ package net.kemitix.thorp.core
 
 import java.nio.file.Path
 
-import net.kemitix.thorp.domain.RemoteKey
+import net.kemitix.thorp.domain.{RemoteKey, Sources}
 
 object KeyGenerator {
 
-  def generateKey(source: Path, prefix: RemoteKey)
+  def generateKey(sources: Sources,
+                  prefix: RemoteKey)
                  (path: Path): RemoteKey = {
+    val source = sources.forPath(path)
     val relativePath = source.relativize(path.toAbsolutePath)
     RemoteKey(s"${prefix.key}/$relativePath")
   }

--- a/core/src/main/scala/net/kemitix/thorp/core/KeyGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/KeyGenerator.scala
@@ -1,16 +1,14 @@
 package net.kemitix.thorp.core
 
-import java.io.File
+import java.nio.file.Path
 
 import net.kemitix.thorp.domain.RemoteKey
 
 object KeyGenerator {
 
-  def generateKey(source: File, prefix: RemoteKey)
-                 (file: File): RemoteKey = {
-    val otherPath = file.toPath.toAbsolutePath
-    val sourcePath = source.toPath
-    val relativePath = sourcePath.relativize(otherPath)
+  def generateKey(source: Path, prefix: RemoteKey)
+                 (path: Path): RemoteKey = {
+    val relativePath = source.relativize(path.toAbsolutePath)
     RemoteKey(s"${prefix.key}/$relativePath")
   }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/LocalFileStream.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/LocalFileStream.scala
@@ -53,6 +53,7 @@ object LocalFileStream {
                         path: Path)
                        (implicit l: Logger, c: Config) = {
     val file = path.toFile
+    val source = c.sources.forPath(path)
     for {
       hash <- hashService.hashLocalObject(path)
     } yield
@@ -60,9 +61,9 @@ object LocalFileStream {
         localFiles = Stream(
           domain.LocalFile(
             file,
-            c.source.toFile,
+            source.toFile,
             hash,
-            generateKey(c.source, c.prefix)(path))),
+            generateKey(c.sources, c.prefix)(path))),
         count = 1,
         totalSizeBytes = file.length)
   }

--- a/core/src/main/scala/net/kemitix/thorp/core/MD5HashGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/MD5HashGenerator.scala
@@ -1,6 +1,7 @@
 package net.kemitix.thorp.core
 
 import java.io.{File, FileInputStream}
+import java.nio.file.Path
 import java.security.MessageDigest
 
 import cats.effect.IO
@@ -25,8 +26,8 @@ object MD5HashGenerator {
     md5.digest
   }
 
-  def md5File(file: File)(implicit logger: Logger): IO[MD5Hash] =
-    md5FileChunk(file, 0, file.length)
+  def md5File(path: Path)(implicit logger: Logger): IO[MD5Hash] =
+    md5FileChunk(path, 0, path.toFile.length)
 
   private def openFile(file: File, offset: Long) = IO {
     val stream = new FileInputStream(file)
@@ -68,16 +69,17 @@ object MD5HashGenerator {
     result.toInt
   }
 
-  def md5FileChunk(file: File,
+  def md5FileChunk(path: Path,
                    offset: Long,
                    size: Long)
                   (implicit logger: Logger): IO[MD5Hash] = {
+    val file = path.toFile
     val endOffset = Math.min(offset + size, file.length)
     for {
-      _ <- logger.debug(s"md5:reading:size ${file.length}:$file")
+      _ <- logger.debug(s"md5:reading:size ${file.length}:$path")
       digest <- readFile(file, offset, endOffset)
       hash = MD5Hash.fromDigest(digest)
-      _ <- logger.debug(s"md5:generated:${hash.hash}:$file")
+      _ <- logger.debug(s"md5:generated:${hash.hash}:$path")
     } yield hash
   }
 

--- a/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
@@ -61,7 +61,7 @@ trait PlanBuilder {
 
   private def actionsForLocalFiles(localData: LocalFiles, remoteData: S3ObjectsData)
                                   (implicit c: Config) =
-    localData.localFiles.foldLeft(Stream[Action]())((acc, lf) => createActionFromLocalFile(lf, remoteData) ++ acc)
+    localData.localFiles.foldLeft(Stream[Action]())((acc, lf) => createActionFromLocalFile(lf, remoteData, acc) ++ acc)
 
   private def actionsForRemoteKeys(remoteData: S3ObjectsData)
                                   (implicit c: Config) =
@@ -93,9 +93,11 @@ trait PlanBuilder {
     } yield localFiles
   }
 
-  private def createActionFromLocalFile(lf: LocalFile, remoteData: S3ObjectsData)
+  private def createActionFromLocalFile(lf: LocalFile,
+                                        remoteData: S3ObjectsData,
+                                        previousActions: Stream[Action])
                                        (implicit c: Config) =
-    ActionGenerator.createActions(S3MetaDataEnricher.getMetadata(lf, remoteData))
+    ActionGenerator.createActions(S3MetaDataEnricher.getMetadata(lf, remoteData), previousActions)
 
   private def createActionFromRemoteKey(rk: RemoteKey)
                                        (implicit c: Config) =

--- a/core/src/main/scala/net/kemitix/thorp/core/SimpleHashService.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SimpleHashService.scala
@@ -1,0 +1,19 @@
+package net.kemitix.thorp.core
+
+import java.nio.file.Path
+
+import cats.effect.IO
+import net.kemitix.thorp.domain.{Logger, MD5Hash}
+import net.kemitix.thorp.storage.api.HashService
+
+case class SimpleHashService() extends HashService {
+
+  override def hashLocalObject(path: Path)
+                              (implicit l: Logger): IO[Map[String, MD5Hash]] =
+    for {
+      md5 <- MD5HashGenerator.md5File(path)
+    } yield Map(
+      "md5" -> md5
+    )
+
+}

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncLogging.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncLogging.scala
@@ -1,6 +1,6 @@
 package net.kemitix.thorp.core
 
-import java.io.File
+import java.nio.file.Path
 
 import cats.effect.IO
 import cats.implicits._
@@ -11,7 +11,7 @@ trait SyncLogging {
 
   def logRunStart(bucket: Bucket,
                   prefix: RemoteKey,
-                  source: File)
+                  source: Path)
                  (implicit logger: Logger): IO[Unit] =
     logger.info(s"Bucket: ${bucket.name}, Prefix: ${prefix.key}, Source: $source, ")
 

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncLogging.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncLogging.scala
@@ -1,7 +1,5 @@
 package net.kemitix.thorp.core
 
-import java.nio.file.Path
-
 import cats.effect.IO
 import cats.implicits._
 import net.kemitix.thorp.domain.StorageQueueEvent.{CopyQueueEvent, DeleteQueueEvent, ErrorQueueEvent, UploadQueueEvent}
@@ -11,13 +9,15 @@ trait SyncLogging {
 
   def logRunStart(bucket: Bucket,
                   prefix: RemoteKey,
-                  source: Path)
-                 (implicit logger: Logger): IO[Unit] =
-    logger.info(s"Bucket: ${bucket.name}, Prefix: ${prefix.key}, Source: $source, ")
+                  sources: Sources)
+                 (implicit logger: Logger): IO[Unit] = {
+    val sourcesList = sources.paths.mkString(", ")
+    logger.info(s"Bucket: ${bucket.name}, Prefix: ${prefix.key}, Source: $sourcesList, ")
+  }
 
   def logFileScan(implicit c: Config,
                   logger: Logger): IO[Unit] =
-    logger.info(s"Scanning local files: ${c.source}...")
+    logger.info(s"Scanning local files: ${c.sources}...")
 
   def logErrors(actions: Stream[StorageQueueEvent])
                (implicit logger: Logger): IO[Unit] =

--- a/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
@@ -10,9 +10,10 @@ class ActionGeneratorSuite
   extends FunSpec {
 
   private val source = Resource(this, "upload")
+  private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
   private val bucket = Bucket("bucket")
-  implicit private val config: Config = Config(bucket, prefix, source = source)
+  implicit private val config: Config = Config(bucket, prefix, source = sourcePath)
   private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
   val lastModified = LastModified(Instant.now())
 
@@ -22,7 +23,7 @@ class ActionGeneratorSuite
 
       describe("#1 local exists, remote exists, remote matches - do nothing") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteMetadata = RemoteMetaData(theFile.remoteKey, theHash, lastModified)
         val input = S3MetaData(theFile, // local exists
           matchByHash = Set(theRemoteMetadata), // remote matches
@@ -36,7 +37,7 @@ class ActionGeneratorSuite
       }
       describe("#2 local exists, remote is missing, other matches - copy") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val otherRemoteKey = prefix.resolve("other-key")
         val otherRemoteMetadata = RemoteMetaData(otherRemoteKey, theHash, lastModified)
@@ -51,7 +52,7 @@ class ActionGeneratorSuite
       }
       describe("#3 local exists, remote is missing, other no matches - upload") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val input = S3MetaData(theFile, // local exists
           matchByHash = Set.empty, // other no matches
           matchByKey = None) // remote is missing
@@ -63,7 +64,7 @@ class ActionGeneratorSuite
       }
       describe("#4 local exists, remote exists, remote no match, other matches - copy") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val oldHash = MD5Hash("old-hash")
         val otherRemoteKey = prefix.resolve("other-key")
@@ -82,7 +83,7 @@ class ActionGeneratorSuite
       }
       describe("#5 local exists, remote exists, remote no match, other no matches - upload") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val oldHash = MD5Hash("old-hash")
         val theRemoteMetadata = RemoteMetaData(theRemoteKey, oldHash, lastModified)

--- a/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
@@ -13,8 +13,8 @@ class ActionGeneratorSuite
   private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
   private val bucket = Bucket("bucket")
-  implicit private val config: Config = Config(bucket, prefix, source = sourcePath)
-  private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
+  implicit private val config: Config = Config(bucket, prefix, sources = Sources(List(sourcePath)))
+  private val fileToKey = KeyGenerator.generateKey(config.sources, config.prefix) _
   val lastModified = LastModified(Instant.now())
 
     describe("create actions") {

--- a/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
@@ -19,7 +19,9 @@ class ActionGeneratorSuite
 
     describe("create actions") {
 
-      def invoke(input: S3MetaData) = ActionGenerator.createActions(input).toList
+      val previousActions = Stream.empty[Action]
+
+      def invoke(input: S3MetaData) = ActionGenerator.createActions(input, previousActions).toList
 
       describe("#1 local exists, remote exists, remote matches - do nothing") {
         val theHash = MD5Hash("the-hash")

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigOptionTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigOptionTest.scala
@@ -1,0 +1,32 @@
+package net.kemitix.thorp.core
+
+import java.nio.file.Paths
+
+import net.kemitix.thorp.domain.Sources
+import org.scalatest.FunSpec
+
+class ConfigOptionTest extends FunSpec {
+
+  private val source = Resource(this, "")
+  private val sourcePath = source.toPath
+
+  describe("when more than one source") {
+    val path1 = sourcePath.resolve("path1")
+    val path2 = sourcePath.resolve("path2")
+    val configOptions = ConfigOptions(List(
+      ConfigOption.Source(path1),
+      ConfigOption.Source(path2),
+      ConfigOption.Bucket("bucket"),
+      ConfigOption.IgnoreGlobalOptions,
+      ConfigOption.IgnoreUserOptions
+    ))
+    val args = ConfigurationBuilder.buildConfig(configOptions).unsafeRunSync
+    it("should successfully parse") {
+      assert(args.isRight, args)
+    }
+    it("should preserve their order") {
+      val expected = Sources(List(path1, path2))
+      assertResult(expected)(ConfigQuery.sources(configOptions))
+    }
+  }
+}

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigOptionTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigOptionTest.scala
@@ -1,32 +1,34 @@
 package net.kemitix.thorp.core
 
-import java.nio.file.Paths
-
 import net.kemitix.thorp.domain.Sources
 import org.scalatest.FunSpec
 
-class ConfigOptionTest extends FunSpec {
+class ConfigOptionTest extends FunSpec with TemporaryFolder {
 
   private val source = Resource(this, "")
   private val sourcePath = source.toPath
 
   describe("when more than one source") {
-    val path1 = sourcePath.resolve("path1")
-    val path2 = sourcePath.resolve("path2")
-    val configOptions = ConfigOptions(List(
-      ConfigOption.Source(path1),
-      ConfigOption.Source(path2),
-      ConfigOption.Bucket("bucket"),
-      ConfigOption.IgnoreGlobalOptions,
-      ConfigOption.IgnoreUserOptions
-    ))
-    val args = ConfigurationBuilder.buildConfig(configOptions).unsafeRunSync
-    it("should successfully parse") {
-      assert(args.isRight, args)
-    }
     it("should preserve their order") {
-      val expected = Sources(List(path1, path2))
-      assertResult(expected)(ConfigQuery.sources(configOptions))
+      withDirectory(path1 => {
+        withDirectory(path2 => {
+          val configOptions = ConfigOptions(List(
+            ConfigOption.Source(path1),
+            ConfigOption.Source(path2),
+            ConfigOption.Bucket("bucket"),
+            ConfigOption.IgnoreGlobalOptions,
+            ConfigOption.IgnoreUserOptions
+          ))
+          val expected = Sources(List(path1, path2))
+          val result = invoke(configOptions)
+          assert(result.isRight, result)
+          assertResult(expected)(ConfigQuery.sources(configOptions))
+        })
+      })
     }
+  }
+
+  private def invoke(configOptions: ConfigOptions) = {
+    ConfigurationBuilder.buildConfig(configOptions).unsafeRunSync
   }
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigOptionTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigOptionTest.scala
@@ -5,9 +5,6 @@ import org.scalatest.FunSpec
 
 class ConfigOptionTest extends FunSpec with TemporaryFolder {
 
-  private val source = Resource(this, "")
-  private val sourcePath = source.toPath
-
   describe("when more than one source") {
     it("should preserve their order") {
       withDirectory(path1 => {

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
@@ -121,13 +121,12 @@ class ConfigurationBuilderTest extends FunSpec with TemporaryFolder {
           writeFile(currentSource, thorpConfigFileName, s"source = $parentSource")
           withDirectory(grandParentSource => {
             writeFile(parentSource, thorpConfigFileName, s"source = $grandParentSource")
-            val expected = List(currentSource, parentSource, grandParentSource)
+            val expected = Right(List(currentSource, parentSource, grandParentSource))
             val options = configOptions(
               ConfigOption.Source(currentSource),
               coBucket)
-            val result = invoke(options)
-            assert(result.isRight, result)
-            assertResult(expected)(result.right.get.sources.paths)
+            val result = invoke(options).map(_.sources.paths)
+            assertResult(expected)(result)
           })
         })
       })

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
@@ -1,130 +1,151 @@
 package net.kemitix.thorp.core
 
-import java.io.{File, PrintWriter}
-import java.nio.file.{Files, Path, Paths}
+import java.io.PrintWriter
+import java.nio.file.{Path, Paths}
 
-import net.kemitix.thorp.domain.{Bucket, Config, Sources}
+import net.kemitix.thorp.domain._
 import org.scalatest.FunSpec
 
-class ConfigurationBuilderTest extends FunSpec {
+class ConfigurationBuilderTest extends FunSpec with TemporaryFolder {
 
-  val validBase =
+  private val pwd: Path = Paths.get(System.getenv("PWD"))
+  private val aBucket = Bucket("aBucket")
+  private val coBucket: ConfigOption.Bucket = ConfigOption.Bucket(aBucket.name)
+  private val thorpConfigFileName = ".thorp.config"
+
+  @deprecated
+  private val validBase =
     ConfigOptions(List(
-      ConfigOption.Bucket("aBucket"),
+      coBucket,
       ConfigOption.IgnoreUserOptions,
       ConfigOption.IgnoreGlobalOptions
     ))
 
-  val aBucket = Bucket("aBucket")
+  private def configOptions(options: ConfigOption*): ConfigOptions =
+    ConfigOptions(List(
+        ConfigOption.IgnoreUserOptions,
+        ConfigOption.IgnoreGlobalOptions
+      ) ++ options)
 
-  val aSource: Path = Resource(this, "upload").toPath
-  val path1: Path = Resource(this, "path1").toPath
-  val path2: Path = Resource(this, "path2").toPath
-  val pwd: Path = Paths.get(System.getenv("PWD"))
-
-  describe("when no source") {
-    val configOptions = validBase
-    it("should use the current (PWD) directory") {
-      val expected = Right(Config(aBucket, sources = Sources(List(pwd))))
-      val result = invoke(configOptions)
-      assertResult(expected)(result)
-    }
-  }
-  describe("when has a single source") {
-    val source = ConfigOption.Source(aSource)
-    val configOptions = validBase ++ ConfigOptions(List(source))
-    it("should only include the source once") {
-      val expected = List(aSource)
-      val result = invoke(configOptions).right.get.sources.paths
-      assertResult(expected)(result)
-    }
-    it("should use the single source") {
-      val expected = Right(Config(aBucket, sources = Sources(List(aSource))))
-      val result = invoke(configOptions)
-      assertResult(expected)(result)
-    }
-  }
-  describe("when has two sources") {
-    val source1 = ConfigOption.Source(aSource)
-    val source2 = ConfigOption.Source(path1)
-    val configOptions = validBase ++ ConfigOptions(List(
-      source1, source2
-    ))
-    it("should include both sources in correct order") {
-      val expected = List(aSource, path1)
-      val result = invoke(configOptions).right.get.sources.paths
-      assertResult(expected)(result)
-    }
-  }
-
-  def writeFile(directory: File, name: String, contents: List[String]): Unit = {
-    directory.mkdirs
-    val pw = new PrintWriter(filename(directory, name), "UTF-8")
+  private def writeFile(directory: Path, name: String, contents: String*): Unit = {
+    directory.toFile.mkdirs
+    val pw = new PrintWriter(directory.resolve(name).toFile, "UTF-8")
     contents.foreach(pw.println)
     pw.close()
   }
 
-  private def filename(directory: File, name: String) =
-    directory.toPath.resolve(name).toFile
 
-  def deleteFile(directory: File, name: String): Unit = {
-    Files.delete(filename(directory, name).toPath)
-    directory.delete
+  describe("when no source") {
+    it("should use the current (PWD) directory") {
+      val expected = Right(Config(aBucket, sources = Sources(List(pwd))))
+      val options = configOptions(coBucket)
+      val result = invoke(options)
+      assert(result.isRight, result)
+      assertResult(expected)(result)
+    }
   }
-
-  val thorpConfigFileName = ".thorp.config"
-
-  describe("when source has thorp.config source to another source") {
-    val currentSourceFile = resourcePath.resolve("parent1").toFile
-    val currentSource = currentSourceFile.toPath
-    val previousSource = path2
-    describe("when settings are only in current") {
-      it("should have bucket from current") {pending}
-      it("should have prefix from current") {pending}
-      it("should have filters from current for current source") {pending}
+  describe("when has a single source with no .thorp.config") {
+    it("should only include the source once") {
+      withDirectory(aSource => {
+        val expected = Sources(List(aSource))
+        val options = configOptions(ConfigOption.Source(aSource), coBucket)
+        val result = invoke(options)
+        assert(result.isRight, result)
+        assertResult(expected)(result.right.get.sources)
+      })
+    }
+  }
+  describe("when has two sources") {
+    it("should include both sources in order") {
+      withDirectory(currentSource => {
+        withDirectory(previousSource => {
+          val expected = List(currentSource, previousSource)
+          val options = configOptions(
+            ConfigOption.Source(currentSource),
+            ConfigOption.Source(previousSource),
+            coBucket)
+          val result = invoke(options)
+          assert(result.isRight, result)
+          assertResult(expected)(result.right.get.sources.paths)
+        })
+      })
+    }
+  }
+  describe("when current source has .thorp.config with source to another") {
+    it("should include both sources in order") {
+      withDirectory(currentSource => {
+        withDirectory(previousSource => {
+          writeFile(currentSource, thorpConfigFileName,
+            s"source = $previousSource")
+          val expected = List(currentSource, previousSource)
+          val options = configOptions(
+            ConfigOption.Source(currentSource),
+            coBucket)
+          val result = invoke(options)
+          assert(result.isRight, result)
+          assertResult(expected)(result.right.get.sources.paths)
+        })
+      })
     }
     describe("when settings are in current and previous") {
-      writeFile(currentSourceFile, thorpConfigFileName, List(s"source = $previousSource"))
-      val source = ConfigOption.Source(currentSource)
-      val configOptions = validBase ++ ConfigOptions(List(source))
-      it("should include both sources") {
-        val expected = List(currentSource, previousSource)
-        val result = invoke(configOptions).right.get.sources.paths
-        deleteFile(currentSourceFile, thorpConfigFileName)
-        assertResult(expected)(result)
+      it("should include some settings from both sources and some from only current") {
+        withDirectory(previousSource => {
+          withDirectory(currentSource => {
+            writeFile(currentSource, thorpConfigFileName,
+              s"source = $previousSource",
+              "bucket = current-bucket",
+              "prefix = current-prefix",
+              "include = current-include",
+              "exclude = current-exclude")
+            writeFile(previousSource, thorpConfigFileName,
+              "bucket = previous-bucket",
+              "prefix = previous-prefix",
+              "include = previous-include",
+              "exclude = previous-exclude")
+            // should have both sources in order
+            val expectedSources = Sources(List(currentSource, previousSource))
+            // should have bucket from current only
+            val expectedBuckets = Bucket("current-bucket")
+            // should have prefix from current only
+            val expectedPrefixes = RemoteKey("current-prefix")
+            // should have filters from both sources
+            val expectedFilters = List(
+              Filter.Exclude("previous-exclude"),
+              Filter.Include("previous-include"),
+              Filter.Exclude("current-exclude"),
+              Filter.Include("current-include"))
+            val options = configOptions(ConfigOption.Source(currentSource))
+            val result = invoke(options)
+            assert(result.isRight, result)
+            val config = result.right.get
+            assertResult(expectedSources)(config.sources)
+            assertResult(expectedBuckets)(config.bucket)
+            assertResult(expectedPrefixes)(config.prefix)
+            assertResult(expectedFilters)(config.filters)
+          })
+        })
       }
-      it("should have bucket from current only") {pending}
-      it("should have prefix from current only") {pending}
-      it("should have filters from both current and previous") {pending}
-    }
-    describe("when settings are only in previous") {
-      it("should have bucket from previous") {pending}
-      it("should have prefix from previous") {pending}
-      it("should have filters from previous for previous source") {pending}
     }
   }
 
   describe("when source has thorp.config source to another source that does the same") {
-    val currentSource = resourcePath.resolve("current")
-    val currentSourceFile = currentSource.toFile
-    val parentSource = resourcePath.resolve("parent")
-    val parentSourceFile = parentSource.toFile
-    val grandParentSource = path2
-    writeFile(currentSourceFile, thorpConfigFileName, List(s"source = $parentSource"))
-    writeFile(parentSourceFile, thorpConfigFileName, List(s"source = $grandParentSource"))
-    val source = ConfigOption.Source(currentSource)
-    val configOptions = validBase ++ ConfigOptions(List(source))
     it("should include all three sources") {
-      val expected = List(currentSource, parentSource, grandParentSource)
-      val result = invoke(configOptions).right.get.sources.paths
-      deleteFile(currentSourceFile, thorpConfigFileName)
-      deleteFile(parentSourceFile, thorpConfigFileName)
-      assertResult(expected)(result)
+      withDirectory(currentSource => {
+        withDirectory(parentSource => {
+          writeFile(currentSource, thorpConfigFileName, s"source = $parentSource")
+          withDirectory(grandParentSource => {
+            writeFile(parentSource, thorpConfigFileName, s"source = $grandParentSource")
+            val expected = List(currentSource, parentSource, grandParentSource)
+            val options = configOptions(
+              ConfigOption.Source(currentSource),
+              coBucket)
+            val result = invoke(options)
+            assert(result.isRight, result)
+            assertResult(expected)(result.right.get.sources.paths)
+          })
+        })
+      })
     }
-  }
-
-  private def resourcePath = {
-    Resource(this, ".").toPath
   }
 
   private def invoke(configOptions: ConfigOptions) =

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
@@ -78,14 +78,29 @@ class ConfigurationBuilderTest extends FunSpec {
     val currentSourceFile = resourcePath.resolve("parent1").toFile
     val currentSource = currentSourceFile.toPath
     val previousSource = path2
-    writeFile(currentSourceFile, thorpConfigFileName, List(s"source = $previousSource"))
-    val source = ConfigOption.Source(currentSource)
-    val configOptions = validBase ++ ConfigOptions(List(source))
-    it("should include both sources") {
-      val expected = List(currentSource, previousSource)
-      val result = invoke(configOptions).right.get.sources.paths
-      deleteFile(currentSourceFile, thorpConfigFileName)
-      assertResult(expected)(result)
+    describe("when settings are only in current") {
+      it("should have bucket from current") {pending}
+      it("should have prefix from current") {pending}
+      it("should have filters from current for current source") {pending}
+    }
+    describe("when settings are in current and previous") {
+      writeFile(currentSourceFile, thorpConfigFileName, List(s"source = $previousSource"))
+      val source = ConfigOption.Source(currentSource)
+      val configOptions = validBase ++ ConfigOptions(List(source))
+      it("should include both sources") {
+        val expected = List(currentSource, previousSource)
+        val result = invoke(configOptions).right.get.sources.paths
+        deleteFile(currentSourceFile, thorpConfigFileName)
+        assertResult(expected)(result)
+      }
+      it("should have bucket from current only") {pending}
+      it("should have prefix from current only") {pending}
+      it("should have filters from both current and previous") {pending}
+    }
+    describe("when settings are only in previous") {
+      it("should have bucket from previous") {pending}
+      it("should have prefix from previous") {pending}
+      it("should have filters from previous for previous source") {pending}
     }
   }
 

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
@@ -1,6 +1,5 @@
 package net.kemitix.thorp.core
 
-import java.io.PrintWriter
 import java.nio.file.{Path, Paths}
 
 import net.kemitix.thorp.domain._
@@ -18,14 +17,6 @@ class ConfigurationBuilderTest extends FunSpec with TemporaryFolder {
         ConfigOption.IgnoreUserOptions,
         ConfigOption.IgnoreGlobalOptions
       ) ++ options)
-
-  private def writeFile(directory: Path, name: String, contents: String*): Unit = {
-    directory.toFile.mkdirs
-    val pw = new PrintWriter(directory.resolve(name).toFile, "UTF-8")
-    contents.foreach(pw.println)
-    pw.close()
-  }
-
 
   describe("when no source") {
     it("should use the current (PWD) directory") {

--- a/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ConfigurationBuilderTest.scala
@@ -1,0 +1,117 @@
+package net.kemitix.thorp.core
+
+import java.io.{File, PrintWriter}
+import java.nio.file.{Files, Path, Paths}
+
+import net.kemitix.thorp.domain.{Bucket, Config, Sources}
+import org.scalatest.FunSpec
+
+class ConfigurationBuilderTest extends FunSpec {
+
+  val validBase =
+    ConfigOptions(List(
+      ConfigOption.Bucket("aBucket"),
+      ConfigOption.IgnoreUserOptions,
+      ConfigOption.IgnoreGlobalOptions
+    ))
+
+  val aBucket = Bucket("aBucket")
+
+  val aSource: Path = Resource(this, "upload").toPath
+  val path1: Path = Resource(this, "path1").toPath
+  val path2: Path = Resource(this, "path2").toPath
+  val pwd: Path = Paths.get(System.getenv("PWD"))
+
+  describe("when no source") {
+    val configOptions = validBase
+    it("should use the current (PWD) directory") {
+      val expected = Right(Config(aBucket, sources = Sources(List(pwd))))
+      val result = invoke(configOptions)
+      assertResult(expected)(result)
+    }
+  }
+  describe("when has a single source") {
+    val source = ConfigOption.Source(aSource)
+    val configOptions = validBase ++ ConfigOptions(List(source))
+    it("should only include the source once") {
+      val expected = List(aSource)
+      val result = invoke(configOptions).right.get.sources.paths
+      assertResult(expected)(result)
+    }
+    it("should use the single source") {
+      val expected = Right(Config(aBucket, sources = Sources(List(aSource))))
+      val result = invoke(configOptions)
+      assertResult(expected)(result)
+    }
+  }
+  describe("when has two sources") {
+    val source1 = ConfigOption.Source(aSource)
+    val source2 = ConfigOption.Source(path1)
+    val configOptions = validBase ++ ConfigOptions(List(
+      source1, source2
+    ))
+    it("should include both sources in correct order") {
+      val expected = List(aSource, path1)
+      val result = invoke(configOptions).right.get.sources.paths
+      assertResult(expected)(result)
+    }
+  }
+
+  def writeFile(directory: File, name: String, contents: List[String]): Unit = {
+    directory.mkdirs
+    val pw = new PrintWriter(filename(directory, name), "UTF-8")
+    contents.foreach(pw.println)
+    pw.close()
+  }
+
+  private def filename(directory: File, name: String) =
+    directory.toPath.resolve(name).toFile
+
+  def deleteFile(directory: File, name: String): Unit = {
+    Files.delete(filename(directory, name).toPath)
+    directory.delete
+  }
+
+  val thorpConfigFileName = ".thorp.config"
+
+  describe("when source has thorp.config source to another source") {
+    val currentSourceFile = resourcePath.resolve("parent1").toFile
+    val currentSource = currentSourceFile.toPath
+    val previousSource = path2
+    writeFile(currentSourceFile, thorpConfigFileName, List(s"source = $previousSource"))
+    val source = ConfigOption.Source(currentSource)
+    val configOptions = validBase ++ ConfigOptions(List(source))
+    it("should include both sources") {
+      val expected = List(currentSource, previousSource)
+      val result = invoke(configOptions).right.get.sources.paths
+      deleteFile(currentSourceFile, thorpConfigFileName)
+      assertResult(expected)(result)
+    }
+  }
+
+  describe("when source has thorp.config source to another source that does the same") {
+    val currentSource = resourcePath.resolve("current")
+    val currentSourceFile = currentSource.toFile
+    val parentSource = resourcePath.resolve("parent")
+    val parentSourceFile = parentSource.toFile
+    val grandParentSource = path2
+    writeFile(currentSourceFile, thorpConfigFileName, List(s"source = $parentSource"))
+    writeFile(parentSourceFile, thorpConfigFileName, List(s"source = $grandParentSource"))
+    val source = ConfigOption.Source(currentSource)
+    val configOptions = validBase ++ ConfigOptions(List(source))
+    it("should include all three sources") {
+      val expected = List(currentSource, parentSource, grandParentSource)
+      val result = invoke(configOptions).right.get.sources.paths
+      deleteFile(currentSourceFile, thorpConfigFileName)
+      deleteFile(parentSourceFile, thorpConfigFileName)
+      assertResult(expected)(result)
+    }
+  }
+
+  private def resourcePath = {
+    Resource(this, ".").toPath
+  }
+
+  private def invoke(configOptions: ConfigOptions) =
+    ConfigurationBuilder.buildConfig(configOptions).unsafeRunSync
+}

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyHashService.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyHashService.scala
@@ -1,11 +1,16 @@
 package net.kemitix.thorp.core
 
-import java.io.File
+import java.nio.file.Path
 
 import cats.effect.IO
 import net.kemitix.thorp.domain.{Logger, MD5Hash}
 import net.kemitix.thorp.storage.api.HashService
 
-case class DummyHashService(hashes: Map[File, Map[String, MD5Hash]]) extends HashService {
-  override def hashLocalObject(file: File)(implicit l: Logger): IO[Map[String, MD5Hash]] = IO.pure(hashes(file))
+case class DummyHashService(hashes: Map[Path, Map[String, MD5Hash]])
+  extends HashService {
+
+  override def hashLocalObject(path: Path)
+                              (implicit l: Logger): IO[Map[String, MD5Hash]] =
+    IO.pure(hashes(path))
+
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import cats.data.EitherT
 import cats.effect.IO
-import net.kemitix.thorp.domain.{Bucket, LocalFile, Logger, MD5Hash, RemoteKey, S3ObjectsData, StorageQueueEvent, UploadEventListener}
+import net.kemitix.thorp.domain._
 import net.kemitix.thorp.storage.api.StorageService
 
 case class DummyStorageService(s3ObjectData: S3ObjectsData,

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
@@ -1,0 +1,41 @@
+package net.kemitix.thorp.core
+
+import java.io.File
+
+import cats.data.EitherT
+import cats.effect.IO
+import net.kemitix.thorp.domain.{Bucket, LocalFile, Logger, MD5Hash, RemoteKey, S3ObjectsData, StorageQueueEvent, UploadEventListener}
+import net.kemitix.thorp.storage.api.StorageService
+
+case class DummyStorageService(s3ObjectData: S3ObjectsData,
+                               uploadFiles: Map[File, (RemoteKey, MD5Hash)])
+  extends StorageService {
+
+  override def shutdown: IO[StorageQueueEvent] =
+    IO.pure(StorageQueueEvent.ShutdownQueueEvent())
+
+  override def listObjects(bucket: Bucket,
+                           prefix: RemoteKey)
+                          (implicit l: Logger): EitherT[IO, String, S3ObjectsData] =
+    EitherT.liftF(IO.pure(s3ObjectData))
+
+  override def upload(localFile: LocalFile,
+                      bucket: Bucket,
+                      batchMode: Boolean,
+                      uploadEventListener: UploadEventListener,
+                      tryCount: Int): IO[StorageQueueEvent] = {
+    val (remoteKey, md5Hash) = uploadFiles(localFile.file)
+    IO.pure(StorageQueueEvent.UploadQueueEvent(remoteKey, md5Hash))
+  }
+
+  override def copy(bucket: Bucket,
+                    sourceKey: RemoteKey,
+                    hash: MD5Hash,
+                    targetKey: RemoteKey): IO[StorageQueueEvent] =
+    IO.pure(StorageQueueEvent.CopyQueueEvent(targetKey))
+
+  override def delete(bucket: Bucket,
+                      remoteKey: RemoteKey): IO[StorageQueueEvent] =
+    IO.pure(StorageQueueEvent.DeleteQueueEvent(remoteKey))
+
+}

--- a/core/src/test/scala/net/kemitix/thorp/core/KeyGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/KeyGeneratorSuite.scala
@@ -2,7 +2,7 @@ package net.kemitix.thorp.core
 
 import java.io.File
 
-import net.kemitix.thorp.domain.{Bucket, Config, RemoteKey}
+import net.kemitix.thorp.domain.{Bucket, Config, RemoteKey, Sources}
 import org.scalatest.FunSpec
 
 class KeyGeneratorSuite extends FunSpec {
@@ -10,8 +10,8 @@ class KeyGeneratorSuite extends FunSpec {
   private val source: File = Resource(this, "upload")
   private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
-  private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, sources = Sources(List(sourcePath)))
+  private val fileToKey = KeyGenerator.generateKey(config.sources, config.prefix) _
 
   describe("key generator") {
 

--- a/core/src/test/scala/net/kemitix/thorp/core/KeyGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/KeyGeneratorSuite.scala
@@ -7,29 +7,27 @@ import org.scalatest.FunSpec
 
 class KeyGeneratorSuite extends FunSpec {
 
-    private val source: File = Resource(this, "upload")
-    private val prefix = RemoteKey("prefix")
-    implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
-    private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
+  private val source: File = Resource(this, "upload")
+  private val sourcePath = source.toPath
+  private val prefix = RemoteKey("prefix")
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
+  private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
 
-    describe("key generator") {
-      def resolve(subdir: String): File = {
-        source.toPath.resolve(subdir).toFile
-      }
+  describe("key generator") {
 
-      describe("when file is within source") {
-        it("has a valid key") {
-          val subdir = "subdir"
-          assertResult(RemoteKey(s"${prefix.key}/$subdir"))(fileToKey(resolve(subdir)))
-        }
-      }
-
-      describe("when file is deeper within source") {
-        it("has a valid key") {
-          val subdir = "subdir/deeper/still"
-          assertResult(RemoteKey(s"${prefix.key}/$subdir"))(fileToKey(resolve(subdir)))
-        }
+    describe("when file is within source") {
+      it("has a valid key") {
+        val subdir = "subdir"
+        assertResult(RemoteKey(s"${prefix.key}/$subdir"))(fileToKey(sourcePath.resolve(subdir)))
       }
     }
+
+    describe("when file is deeper within source") {
+      it("has a valid key") {
+        val subdir = "subdir/deeper/still"
+        assertResult(RemoteKey(s"${prefix.key}/$subdir"))(fileToKey(sourcePath.resolve(subdir)))
+      }
+    }
+  }
 
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
@@ -8,16 +8,17 @@ import org.scalatest.FunSpec
 
 class LocalFileStreamSuite extends FunSpec {
 
-  private val uploadResource = Resource(this, "upload")
+  private val source = Resource(this, "upload")
+  private val sourcePath = source.toPath
   private val hashService: HashService = DummyHashService(Map(
     file("root-file") -> Map("md5" -> MD5HashData.Root.hash),
     file("subdir/leaf-file") -> Map("md5" -> MD5HashData.Leaf.hash)
   ))
 
   private def file(filename: String) =
-    uploadResource.toPath.resolve(Paths.get(filename)).toFile
+    sourcePath.resolve(Paths.get(filename))
 
-  implicit private val config: Config = Config(source = uploadResource)
+  implicit private val config: Config = Config(source = sourcePath)
   implicit private val logger: Logger = new DummyLogger
 
   describe("findFiles") {
@@ -37,7 +38,7 @@ class LocalFileStreamSuite extends FunSpec {
     }
   }
 
-  private def invoke = {
-    LocalFileStream.findFiles(uploadResource, hashService).unsafeRunSync
-  }
+  private def invoke =
+    LocalFileStream.findFiles(sourcePath, hashService).unsafeRunSync
+
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
@@ -2,7 +2,7 @@ package net.kemitix.thorp.core
 
 import java.nio.file.Paths
 
-import net.kemitix.thorp.domain.{Config, LocalFile, Logger, MD5HashData}
+import net.kemitix.thorp.domain.{Config, LocalFile, Logger, MD5HashData, Sources}
 import net.kemitix.thorp.storage.api.HashService
 import org.scalatest.FunSpec
 
@@ -18,7 +18,7 @@ class LocalFileStreamSuite extends FunSpec {
   private def file(filename: String) =
     sourcePath.resolve(Paths.get(filename))
 
-  implicit private val config: Config = Config(source = sourcePath)
+  implicit private val config: Config = Config(sources = Sources(List(sourcePath)))
   implicit private val logger: Logger = new DummyLogger
 
   describe("findFiles") {

--- a/core/src/test/scala/net/kemitix/thorp/core/MD5HashGeneratorTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/MD5HashGeneratorTest.scala
@@ -7,37 +7,38 @@ import org.scalatest.FunSpec
 class MD5HashGeneratorTest extends FunSpec {
 
   private val source = Resource(this, "upload")
+  private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
   implicit private val logger: Logger = new DummyLogger
 
   describe("read a small file (smaller than buffer)") {
-    val file = Resource(this, "upload/root-file")
+    val path = Resource(this, "upload/root-file").toPath
     it("should generate the correct hash") {
-      val result = MD5HashGenerator.md5File(file).unsafeRunSync
+      val result = MD5HashGenerator.md5File(path).unsafeRunSync
       assertResult(Root.hash)(result)
     }
   }
   describe("read a large file (bigger than buffer)") {
-    val file = Resource(this, "big-file")
+    val path = Resource(this, "big-file").toPath
     it("should generate the correct hash") {
       val expected = MD5HashData.BigFile.hash
-      val result = MD5HashGenerator.md5File(file).unsafeRunSync
+      val result = MD5HashGenerator.md5File(path).unsafeRunSync
       assertResult(expected)(result)
     }
   }
   describe("read chunks of file") {
-    val file = Resource(this, "big-file")
+    val path = Resource(this, "big-file").toPath
     it("should generate the correct hash for first chunk of the file") {
       val part1 = MD5HashData.BigFile.Part1
       val expected = part1.hash
-      val result = MD5HashGenerator.md5FileChunk(file, part1.offset, part1.size).unsafeRunSync
+      val result = MD5HashGenerator.md5FileChunk(path, part1.offset, part1.size).unsafeRunSync
       assertResult(expected)(result)
     }
     it("should generate the correcy hash for second chunk of the file") {
       val part2 = MD5HashData.BigFile.Part2
       val expected = part2.hash
-      val result = MD5HashGenerator.md5FileChunk(file, part2.offset, part2.size).unsafeRunSync
+      val result = MD5HashGenerator.md5FileChunk(path, part2.offset, part2.size).unsafeRunSync
       assertResult(expected)(result)
     }
   }

--- a/core/src/test/scala/net/kemitix/thorp/core/MD5HashGeneratorTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/MD5HashGeneratorTest.scala
@@ -9,7 +9,7 @@ class MD5HashGeneratorTest extends FunSpec {
   private val source = Resource(this, "upload")
   private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, sources = Sources(List(sourcePath)))
   implicit private val logger: Logger = new DummyLogger
 
   describe("read a small file (smaller than buffer)") {

--- a/core/src/test/scala/net/kemitix/thorp/core/PlanBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/PlanBuilderTest.scala
@@ -1,0 +1,110 @@
+package net.kemitix.thorp.core
+
+import java.io.File
+import java.nio.file.Path
+
+import net.kemitix.thorp.core.Action.ToUpload
+import net.kemitix.thorp.domain.{Bucket, LocalFile, Logger, MD5Hash, RemoteKey, S3ObjectsData}
+import net.kemitix.thorp.storage.api.{HashService, StorageService}
+import org.scalatest.FreeSpec
+
+class PlanBuilderTest extends FreeSpec with TemporaryFolder {
+
+  private val planBuilder = new PlanBuilder {}
+  private val emptyS3ObjectData = S3ObjectsData(Map(), Map())
+  private implicit val logger: Logger = new DummyLogger
+
+  "create a plan" - {
+
+    val filename1 = "file-1"
+    val filename2 = "file-2"
+    val hashService = SimpleHashService()
+
+    "two sources" - {
+      "unique files in both" - {
+        "upload all files" in {
+          withDirectory(firstSource => {
+            val fileInFirstSource = createFile(firstSource, filename1, "file-1-content")
+            val hash1 = hashService.hashLocalObject(fileInFirstSource.toPath).unsafeRunSync()("md5")
+
+            withDirectory(secondSource => {
+              val fileInSecondSource = createFile(secondSource, filename2, "file-2-content")
+              val hash2 = hashService.hashLocalObject(fileInSecondSource.toPath).unsafeRunSync()("md5")
+
+              val remoteKey1 = RemoteKey(filename1)
+              val remoteKey2 = RemoteKey(filename2)
+
+              val expected = Right(List(
+                toUpload(secondSource, fileInSecondSource, hash2, remoteKey2),
+                toUpload(firstSource, fileInFirstSource, hash1, remoteKey1)
+              ))
+
+              val storageService = DummyStorageService(emptyS3ObjectData, Map(
+                fileInFirstSource -> (remoteKey1, hash1),
+                fileInSecondSource -> (remoteKey2, hash2)))
+
+              val result = invoke(storageService, hashService, configOptions(
+                ConfigOption.Source(firstSource),
+                ConfigOption.Source(secondSource),
+                ConfigOption.Bucket("a-bucket")))
+
+              assertResult(expected)(result)
+            })
+          })
+        }
+      }
+      "same filename in both" - {
+        "only upload file in first source" in {
+          withDirectory(firstSource => {
+              val fileInFirstSource: File = createFile(firstSource, filename1, "file-1-content")
+              val hash1 = hashService.hashLocalObject(fileInFirstSource.toPath).unsafeRunSync()("md5")
+
+            withDirectory(secondSource => {
+              val fileInSecondSource: File = createFile(secondSource, filename1, "file-2-content")
+              val hash2 = hashService.hashLocalObject(fileInSecondSource.toPath).unsafeRunSync()("md5")
+
+              val remoteKey1 = RemoteKey(filename1)
+              val remoteKey2 = RemoteKey(filename1)
+
+              val expected = Right(List(
+                toUpload(firstSource, fileInFirstSource, hash1, remoteKey1)
+              ))
+
+              val storageService = DummyStorageService(emptyS3ObjectData, Map(
+                fileInFirstSource -> (remoteKey1, hash1),
+                fileInSecondSource -> (remoteKey2, hash2)))
+
+              val result = invoke(storageService, hashService, configOptions(
+                ConfigOption.Source(firstSource),
+                ConfigOption.Source(secondSource),
+                ConfigOption.Bucket("a-bucket")))
+
+              assertResult(expected)(result)
+            })
+          })
+        }
+      }
+      "with remote file only present in second source" ignore  {}
+      "with remote file only present in first source" ignore  {}
+    }
+  }
+
+  private def toUpload(source: Path,
+                       file: File,
+                       md5Hash: MD5Hash,
+                       remoteKey: RemoteKey) =
+    ("upload", file.toString, source.toString, md5Hash.hash, "/" + remoteKey.key)
+
+  private def configOptions(configOptions: ConfigOption*): ConfigOptions =
+    ConfigOptions(List(configOptions:_*))
+
+  private def invoke(storageService: StorageService,
+                     hashService: HashService,
+                     configOptions: ConfigOptions): Either[List[String], List[(String, String, String, String, String)]] =
+    planBuilder.createPlan(storageService, hashService, configOptions)
+      .value.unsafeRunSync().map(_.actions.toList.map({
+      case ToUpload(_, lf, _) => ("upload", lf.file.toString, lf.source.toString, lf.hashes("md5").hash, lf.remoteKey.key)
+      case _ => ("other", "", "", "", "")
+    }))
+
+}

--- a/core/src/test/scala/net/kemitix/thorp/core/PlanBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/PlanBuilderTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.FreeSpec
 class PlanBuilderTest extends FreeSpec with TemporaryFolder {
 
   private val planBuilder = new PlanBuilder {}
-  private val emptyS3ObjectData = S3ObjectsData(Map(), Map())
+  private val emptyS3ObjectData = S3ObjectsData()
   private implicit val logger: Logger = new DummyLogger
 
   val lastModified: LastModified = LastModified()

--- a/core/src/test/scala/net/kemitix/thorp/core/PlanBuilderTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/PlanBuilderTest.scala
@@ -29,11 +29,11 @@ class PlanBuilderTest extends FreeSpec with TemporaryFolder {
         "upload all files" in {
           withDirectory(firstSource => {
             val fileInFirstSource = createFile(firstSource, filename1, "file-1-content")
-            val hash1 = hashService.hashLocalObject(fileInFirstSource.toPath).unsafeRunSync()("md5")
+            val hash1 = md5Hash(fileInFirstSource)
 
             withDirectory(secondSource => {
               val fileInSecondSource = createFile(secondSource, filename2, "file-2-content")
-              val hash2 = hashService.hashLocalObject(fileInSecondSource.toPath).unsafeRunSync()("md5")
+              val hash2 = md5Hash(fileInSecondSource)
 
               val expected = Right(List(
                 toUpload(remoteKey2, hash2, secondSource, fileInSecondSource),
@@ -58,11 +58,11 @@ class PlanBuilderTest extends FreeSpec with TemporaryFolder {
         "only upload file in first source" in {
           withDirectory(firstSource => {
             val fileInFirstSource: File = createFile(firstSource, filename1, "file-1-content")
-            val hash1 = hashService.hashLocalObject(fileInFirstSource.toPath).unsafeRunSync()("md5")
+            val hash1 = md5Hash(fileInFirstSource)
 
             withDirectory(secondSource => {
               val fileInSecondSource: File = createFile(secondSource, filename1, "file-2-content")
-              val hash2 = hashService.hashLocalObject(fileInSecondSource.toPath).unsafeRunSync()("md5")
+              val hash2 = md5Hash(fileInSecondSource)
 
               val expected = Right(List(
                 toUpload(remoteKey1, hash1, firstSource, fileInFirstSource)
@@ -88,7 +88,7 @@ class PlanBuilderTest extends FreeSpec with TemporaryFolder {
 
             withDirectory(secondSource => {
               val fileInSecondSource = createFile(secondSource, filename2, "file-2-content")
-              val hash2 = hashService.hashLocalObject(fileInSecondSource.toPath).unsafeRunSync()("md5")
+              val hash2 = md5Hash(fileInSecondSource)
 
               val expected = Right(List())
 
@@ -113,7 +113,7 @@ class PlanBuilderTest extends FreeSpec with TemporaryFolder {
         "do not delete it" in {
           withDirectory(firstSource => {
             val fileInFirstSource: File = createFile(firstSource, filename1, "file-1-content")
-            val hash1 = hashService.hashLocalObject(fileInFirstSource.toPath).unsafeRunSync()("md5")
+            val hash1 = md5Hash(fileInFirstSource)
 
             withDirectory(secondSource => {
 
@@ -160,6 +160,11 @@ class PlanBuilderTest extends FreeSpec with TemporaryFolder {
         }
       }
     }
+
+    def md5Hash(file: File) = {
+      hashService.hashLocalObject(file.toPath).unsafeRunSync()("md5")
+    }
+
   }
 
   private def toUpload(remoteKey: RemoteKey,

--- a/core/src/test/scala/net/kemitix/thorp/core/S3MetaDataEnricherSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/S3MetaDataEnricherSuite.scala
@@ -82,10 +82,7 @@ class S3MetaDataEnricherSuite
       describe("#3 local exists, remote is missing, remote no match, other no matches - upload") {
         val theHash = MD5Hash("the-hash")
         val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
-        val s3: S3ObjectsData = S3ObjectsData(
-          byHash = Map(),
-          byKey = Map()
-        )
+        val s3: S3ObjectsData = S3ObjectsData()
         it("generates valid metadata") {
           val expected = S3MetaData(theFile,
             matchByHash = Set.empty,

--- a/core/src/test/scala/net/kemitix/thorp/core/S3MetaDataEnricherSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/S3MetaDataEnricherSuite.scala
@@ -10,8 +10,9 @@ class S3MetaDataEnricherSuite
   extends FunSpec {
 
   private val source = Resource(this, "upload")
+  private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
   private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
   val lastModified = LastModified(Instant.now())
 
@@ -29,7 +30,7 @@ class S3MetaDataEnricherSuite
 
       describe("#1a local exists, remote exists, remote matches, other matches - do nothing") {
         val theHash: MD5Hash = MD5Hash("the-file-hash")
-        val theFile: LocalFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile: LocalFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteKey: RemoteKey = theFile.remoteKey
         val s3: S3ObjectsData = S3ObjectsData(
           byHash = Map(theHash -> Set(KeyModified(theRemoteKey, lastModified))),
@@ -46,7 +47,7 @@ class S3MetaDataEnricherSuite
       }
       describe("#1b local exists, remote exists, remote matches, other no matches - do nothing") {
         val theHash: MD5Hash = MD5Hash("the-file-hash")
-        val theFile: LocalFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile: LocalFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteKey: RemoteKey = prefix.resolve("the-file")
         val s3: S3ObjectsData = S3ObjectsData(
           byHash = Map(theHash -> Set(KeyModified(theRemoteKey, lastModified))),
@@ -63,7 +64,7 @@ class S3MetaDataEnricherSuite
       }
       describe("#2 local exists, remote is missing, remote no match, other matches - copy") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val otherRemoteKey = RemoteKey("other-key")
         val s3: S3ObjectsData = S3ObjectsData(
           byHash = Map(theHash -> Set(KeyModified(otherRemoteKey, lastModified))),
@@ -80,7 +81,7 @@ class S3MetaDataEnricherSuite
       }
       describe("#3 local exists, remote is missing, remote no match, other no matches - upload") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val s3: S3ObjectsData = S3ObjectsData(
           byHash = Map(),
           byKey = Map()
@@ -95,7 +96,7 @@ class S3MetaDataEnricherSuite
       }
       describe("#4 local exists, remote exists, remote no match, other matches - copy") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val oldHash = MD5Hash("old-hash")
         val otherRemoteKey = prefix.resolve("other-key")
@@ -120,7 +121,7 @@ class S3MetaDataEnricherSuite
       }
       describe("#5 local exists, remote exists, remote no match, other no matches - upload") {
         val theHash = MD5Hash("the-hash")
-        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), source, fileToKey)
+        val theFile = LocalFile.resolve("the-file", md5HashMap(theHash), sourcePath, fileToKey)
         val theRemoteKey = theFile.remoteKey
         val oldHash = MD5Hash("old-hash")
         val s3: S3ObjectsData = S3ObjectsData(
@@ -148,11 +149,11 @@ class S3MetaDataEnricherSuite
 
   describe("getS3Status") {
     val hash = MD5Hash("hash")
-    val localFile = LocalFile.resolve("the-file", md5HashMap(hash), source, fileToKey)
+    val localFile = LocalFile.resolve("the-file", md5HashMap(hash), sourcePath, fileToKey)
     val key = localFile.remoteKey
-    val keyOtherKey = LocalFile.resolve("other-key-same-hash", md5HashMap(hash), source, fileToKey)
+    val keyOtherKey = LocalFile.resolve("other-key-same-hash", md5HashMap(hash), sourcePath, fileToKey)
     val diffHash = MD5Hash("diff")
-    val keyDiffHash = LocalFile.resolve("other-key-diff-hash", md5HashMap(diffHash), source, fileToKey)
+    val keyDiffHash = LocalFile.resolve("other-key-diff-hash", md5HashMap(diffHash), sourcePath, fileToKey)
     val lastModified = LastModified(Instant.now)
     val s3ObjectsData: S3ObjectsData = S3ObjectsData(
       byHash = Map(
@@ -175,7 +176,7 @@ class S3MetaDataEnricherSuite
     }
 
     describe("when remote key does not exist and no others matches hash") {
-      val localFile = LocalFile.resolve("missing-file", md5HashMap(MD5Hash("unique")), source, fileToKey)
+      val localFile = LocalFile.resolve("missing-file", md5HashMap(MD5Hash("unique")), sourcePath, fileToKey)
       it("should return no matches by key") {
         val result = getMatchesByKey(invoke(localFile))
         assert(result.isEmpty)

--- a/core/src/test/scala/net/kemitix/thorp/core/S3MetaDataEnricherSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/S3MetaDataEnricherSuite.scala
@@ -12,8 +12,8 @@ class S3MetaDataEnricherSuite
   private val source = Resource(this, "upload")
   private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
-  private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, sources = Sources(List(sourcePath)))
+  private val fileToKey = KeyGenerator.generateKey(config.sources, config.prefix) _
   val lastModified = LastModified(Instant.now())
 
   def getMatchesByKey(status: (Option[HashModified], Set[(MD5Hash, KeyModified)])): Option[HashModified] = {

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -21,7 +21,7 @@ class SyncSuite
   private val prefix = RemoteKey("prefix")
   private val configOptions =
     ConfigOptions(List(
-      ConfigOption.Source(source.toPath),
+      ConfigOption.Source(sourcePath),
       ConfigOption.Bucket("bucket"),
       ConfigOption.Prefix("prefix"),
       ConfigOption.IgnoreGlobalOptions,

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -17,6 +17,7 @@ class SyncSuite
   extends FunSpec {
 
   private val source = Resource(this, "upload")
+  private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
   private val configOptions = ConfigOptions(List(
     ConfigOption.Source(source.toPath),
@@ -35,13 +36,13 @@ class SyncSuite
   // source contains the files root-file and subdir/leaf-file
   val rootRemoteKey = RemoteKey("prefix/root-file")
   val leafRemoteKey = RemoteKey("prefix/subdir/leaf-file")
-  val rootFile: LocalFile = LocalFile.resolve("root-file", md5HashMap(Root.hash), source, _ => rootRemoteKey)
+  val rootFile: LocalFile = LocalFile.resolve("root-file", md5HashMap(Root.hash), sourcePath, _ => rootRemoteKey)
 
   private def md5HashMap(md5Hash: MD5Hash): Map[String, MD5Hash] = {
     Map("md5" -> md5Hash)
   }
 
-  val leafFile: LocalFile = LocalFile.resolve("subdir/leaf-file", md5HashMap(Leaf.hash), source, _ => leafRemoteKey)
+  val leafFile: LocalFile = LocalFile.resolve("subdir/leaf-file", md5HashMap(Leaf.hash), sourcePath, _ => leafRemoteKey)
 
   val hashService = DummyHashService(Map(
     file("root-file") -> Map("md5" -> MD5HashData.Root.hash),
@@ -75,7 +76,7 @@ class SyncSuite
   }
 
   private def file(filename: String) =
-    source.toPath.resolve(Paths.get(filename)).toFile
+    sourcePath.resolve(Paths.get(filename))
 
   describe("when no files should be uploaded") {
     val s3ObjectsData = S3ObjectsData(

--- a/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/SyncSuite.scala
@@ -68,9 +68,7 @@ class SyncSuite
   }
 
   describe("when all files should be uploaded") {
-    val storageService = new RecordingStorageService(testBucket, S3ObjectsData(
-      byHash = Map(),
-      byKey = Map()))
+    val storageService = new RecordingStorageService(testBucket, S3ObjectsData())
     it("uploads all files") {
       val expected = Right(Set(
         ToUpload(testBucket, rootFile, rootFile.file.length),

--- a/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
@@ -1,7 +1,8 @@
 package net.kemitix.thorp.core
 
 import java.io.IOException
-import java.nio.file.{Files, Path}
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
 trait TemporaryFolder {
 
@@ -14,9 +15,6 @@ trait TemporaryFolder {
       remove(dir)
     }
   }
-
-  import java.nio.file.attribute.BasicFileAttributes
-  import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
   def remove(root: Path): Unit = {
     Files.walkFileTree(root, new SimpleFileVisitor[Path] {

--- a/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
@@ -4,16 +4,14 @@ import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
+import scala.util.Try
+
 trait TemporaryFolder {
 
   def withDirectory(testCode: Path => Any): Unit = {
     val dir: Path = Files.createTempDirectory("thorp-temp")
-    try {
-      testCode(dir)
-    }
-    finally {
-      remove(dir)
-    }
+    Try(testCode(dir)).recover({ case _ => Nil })
+    remove(dir)
   }
 
   def remove(root: Path): Unit = {

--- a/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
@@ -1,6 +1,6 @@
 package net.kemitix.thorp.core
 
-import java.io.IOException
+import java.io.{File, IOException, PrintWriter}
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
@@ -27,4 +27,17 @@ trait TemporaryFolder {
       }
     })
   }
+
+  def writeFile(directory: Path, name: String, contents: String*): Unit = {
+    directory.toFile.mkdirs
+    val pw = new PrintWriter(directory.resolve(name).toFile, "UTF-8")
+    contents.foreach(pw.println)
+    pw.close()
+  }
+
+  def createFile(path: Path, name: String, content: String*): File = {
+    writeFile(path, name, content:_*)
+    path.resolve(name).toFile
+  }
+
 }

--- a/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
@@ -1,0 +1,33 @@
+package net.kemitix.thorp.core
+
+import java.io.IOException
+import java.nio.file.{Files, Path}
+
+trait TemporaryFolder {
+
+  def withDirectory(testCode: Path => Any): Unit = {
+    val dir: Path = Files.createTempDirectory("thorp-temp")
+    try {
+      testCode(dir)
+    }
+    finally {
+      remove(dir)
+    }
+  }
+
+  import java.nio.file.attribute.BasicFileAttributes
+  import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+  def remove(root: Path): Unit = {
+    Files.walkFileTree(root, new SimpleFileVisitor[Path] {
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.delete(file)
+        FileVisitResult.CONTINUE
+      }
+      override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+        Files.delete(dir)
+        FileVisitResult.CONTINUE
+      }
+    })
+  }
+}

--- a/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/TemporaryFolder.scala
@@ -8,10 +8,11 @@ import scala.util.Try
 
 trait TemporaryFolder {
 
-  def withDirectory(testCode: Path => Any): Unit = {
+  def withDirectory(testCode: Path => Any): Any = {
     val dir: Path = Files.createTempDirectory("thorp-temp")
-    Try(testCode(dir)).recover({ case _ => Nil })
+    val t = Try(testCode(dir))
     remove(dir)
+    t.get
   }
 
   def remove(root: Path): Unit = {

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
@@ -1,10 +1,10 @@
 package net.kemitix.thorp.domain
 
-import java.io.File
+import java.nio.file.Path
 
 final case class Config(bucket: Bucket = Bucket(""),
                         prefix: RemoteKey = RemoteKey(""),
                         filters: List[Filter] = List(),
                         debug: Boolean = false,
                         batchMode: Boolean = false,
-                        source: File)
+                        source: Path)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
@@ -1,10 +1,8 @@
 package net.kemitix.thorp.domain
 
-import java.nio.file.Path
-
 final case class Config(bucket: Bucket = Bucket(""),
                         prefix: RemoteKey = RemoteKey(""),
                         filters: List[Filter] = List(),
                         debug: Boolean = false,
                         batchMode: Boolean = false,
-                        source: Path)
+                        sources: Sources)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/LastModified.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/LastModified.scala
@@ -2,4 +2,4 @@ package net.kemitix.thorp.domain
 
 import java.time.Instant
 
-final case class LastModified(when: Instant)
+final case class LastModified(when: Instant = Instant.now)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/LocalFile.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/LocalFile.scala
@@ -21,9 +21,9 @@ final case class LocalFile(file: File, source: File, hashes: Map[String, MD5Hash
 object LocalFile {
   def resolve(path: String,
               md5Hashes: Map[String, MD5Hash],
-              source: File,
-              fileToKey: File => RemoteKey): LocalFile = {
-    val file = source.toPath.resolve(path).toFile
-    LocalFile(file, source, md5Hashes, fileToKey(file))
+              source: Path,
+              pathToKey: Path => RemoteKey): LocalFile = {
+    val resolvedPath = source.resolve(path)
+    LocalFile(resolvedPath.toFile, source.toFile, md5Hashes, pathToKey(resolvedPath))
   }
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
@@ -5,20 +5,24 @@ import java.nio.file.{Path, Paths}
 
 final case class RemoteKey(key: String) {
 
-  def asFile(source: Path, prefix: RemoteKey): File =
-    source.resolve(relativeTo(prefix)).toFile
+  def asFile(source: Path, prefix: RemoteKey): Option[File] =
+    if (key.length == 0) None
+    else Some(source.resolve(relativeTo(prefix)).toFile)
 
   private def relativeTo(prefix: RemoteKey) = {
     prefix match {
-      case RemoteKey("") => Paths.get(prefix.key)
+      case RemoteKey("") => Paths.get(key)
       case _ => Paths.get(prefix.key).relativize(Paths.get(key))
     }
   }
 
   def isMissingLocally(sources: Sources, prefix: RemoteKey): Boolean =
-    !sources.paths.exists(source => asFile(source, prefix).exists)
+    !sources.paths.exists(source => asFile(source, prefix) match {
+      case Some(file) => file.exists
+      case None => false
+    })
 
   def resolve(path: String): RemoteKey =
-    RemoteKey(key + "/" + path)
+    RemoteKey(List(key, path).filterNot(_.isEmpty).mkString("/"))
 
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
@@ -15,8 +15,8 @@ final case class RemoteKey(key: String) {
     }
   }
 
-  def isMissingLocally(source: Path, prefix: RemoteKey): Boolean =
-    ! asFile(source, prefix).exists
+  def isMissingLocally(sources: Sources, prefix: RemoteKey): Boolean =
+    !sources.paths.exists(source => asFile(source, prefix).exists)
 
   def resolve(path: String): RemoteKey =
     RemoteKey(key + "/" + path)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
@@ -1,12 +1,12 @@
 package net.kemitix.thorp.domain
 
 import java.io.File
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 
 final case class RemoteKey(key: String) {
 
-  def asFile(source: File, prefix: RemoteKey): File =
-    source.toPath.resolve(relativeTo(prefix)).toFile
+  def asFile(source: Path, prefix: RemoteKey): File =
+    source.resolve(relativeTo(prefix)).toFile
 
   private def relativeTo(prefix: RemoteKey) = {
     prefix match {
@@ -15,7 +15,7 @@ final case class RemoteKey(key: String) {
     }
   }
 
-  def isMissingLocally(source: File, prefix: RemoteKey): Boolean =
+  def isMissingLocally(source: Path, prefix: RemoteKey): Boolean =
     ! asFile(source, prefix).exists
 
   def resolve(path: String): RemoteKey =

--- a/domain/src/main/scala/net/kemitix/thorp/domain/S3ObjectsData.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/S3ObjectsData.scala
@@ -3,5 +3,5 @@ package net.kemitix.thorp.domain
 /**
   * A list of objects and their MD5 hash values.
   */
-final case class S3ObjectsData(byHash: Map[MD5Hash, Set[KeyModified]],
-                               byKey: Map[RemoteKey, HashModified])
+final case class S3ObjectsData(byHash: Map[MD5Hash, Set[KeyModified]] = Map.empty,
+                               byKey: Map[RemoteKey, HashModified] = Map.empty)

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
@@ -1,0 +1,15 @@
+package net.kemitix.thorp.domain
+
+import java.nio.file.Path
+
+/**
+  * The paths to synchronise with target.
+  *
+  * The first source path takes priority over those later in the list,
+  * etc. Where there is any file with the same relative path within
+  * more than one source, the file in the first listed path is
+  * uploaded, and the others are ignored.
+  */
+case class Sources(paths: List[Path]) {
+
+}

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
@@ -11,5 +11,15 @@ import java.nio.file.Path
   * uploaded, and the others are ignored.
   */
 case class Sources(paths: List[Path]) {
+  def ++(path: Path): Sources = Sources(paths ++ List(path))
 
+  /**
+    * Returns the source path for the given path.
+    *
+    * @param path the path to find the matching source
+    * @return the source for the path
+    * @throws NoSuchElementException if no source matches the path
+    */
+  def forPath(path: Path): Path =
+    paths.find(source => path.startsWith(source)).get
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
@@ -11,7 +11,8 @@ import java.nio.file.Path
   * uploaded, and the others are ignored.
   */
 case class Sources(paths: List[Path]) {
-  def ++(path: Path): Sources = Sources(paths ++ List(path))
+  def ++(path: Path): Sources = this ++ List(path)
+  def ++(otherPaths: List[Path]): Sources = Sources(paths ++ otherPaths)
 
   /**
     * Returns the source path for the given path.

--- a/domain/src/test/scala/net/kemitix/thorp/domain/RemoteKeyTest.scala
+++ b/domain/src/test/scala/net/kemitix/thorp/domain/RemoteKeyTest.scala
@@ -1,0 +1,72 @@
+package net.kemitix.thorp.domain
+
+import java.io.File
+import java.nio.file.Paths
+
+import org.scalatest.FreeSpec
+
+class RemoteKeyTest extends FreeSpec {
+
+  private val emptyKey = RemoteKey("")
+
+  "create a RemoteKey" - {
+    "can resolve a path" - {
+      "when key is empty" in {
+        val key = emptyKey
+        val path = "path"
+        val expected = RemoteKey("path")
+        val result = key.resolve(path)
+        assertResult(expected)(result)
+      }
+      "when path is empty" in  {
+        val key = RemoteKey("key")
+        val path = ""
+        val expected = RemoteKey("key")
+        val result = key.resolve(path)
+        assertResult(expected)(result)
+      }
+      "when key and path are empty" in {
+        val key = emptyKey
+        val path = ""
+        val expected = emptyKey
+        val result = key.resolve(path)
+        assertResult(expected)(result)
+      }
+    }
+    "asFile" - {
+      "when key and prefix are non-empty" in {
+        val key = RemoteKey("prefix/key")
+        val source = Paths.get("source")
+        val prefix = RemoteKey("prefix")
+        val expected = Some(new File("source/key"))
+        val result = key.asFile(source, prefix)
+        assertResult(expected)(result)
+      }
+      "when prefix is empty" in {
+        val key = RemoteKey("key")
+        val source = Paths.get("source")
+        val prefix = emptyKey
+        val expected = Some(new File("source/key"))
+        val result = key.asFile(source, prefix)
+        assertResult(expected)(result)
+      }
+      "when key is empty" in {
+        val key = emptyKey
+        val source = Paths.get("source")
+        val prefix = RemoteKey("prefix")
+        val expected = None
+        val result = key.asFile(source, prefix)
+        assertResult(expected)(result)
+      }
+      "when key and prefix are empty" in {
+        val key = emptyKey
+        val source = Paths.get("source")
+        val prefix = emptyKey
+        val expected = None
+        val result = key.asFile(source, prefix)
+        assertResult(expected)(result)
+      }
+    }
+  }
+
+}

--- a/storage-api/src/main/scala/net/kemitix/thorp/storage/api/HashService.scala
+++ b/storage-api/src/main/scala/net/kemitix/thorp/storage/api/HashService.scala
@@ -1,6 +1,6 @@
 package net.kemitix.thorp.storage.api
 
-import java.io.File
+import java.nio.file.Path
 
 import cats.effect.IO
 import net.kemitix.thorp.domain.{Logger, MD5Hash}
@@ -10,6 +10,7 @@ import net.kemitix.thorp.domain.{Logger, MD5Hash}
   */
 trait HashService {
 
-  def hashLocalObject(file: File)(implicit l: Logger): IO[Map[String, MD5Hash]]
+  def hashLocalObject(path: Path)
+                     (implicit l: Logger): IO[Map[String, MD5Hash]]
 
 }

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3HashService.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3HashService.scala
@@ -1,6 +1,6 @@
 package net.kemitix.thorp.storage.aws
 
-import java.io.File
+import java.nio.file.Path
 
 import cats.effect.IO
 import net.kemitix.thorp.core.MD5HashGenerator
@@ -12,13 +12,14 @@ trait S3HashService extends HashService {
   /**
     * Generates an MD5 Hash and an multi-part ETag
     *
-    * @param file the local file to scan
+    * @param path the local path to scan
     * @return a set of hash values
     */
-  override def hashLocalObject(file: File)(implicit l: Logger): IO[Map[String, MD5Hash]] =
+  override def hashLocalObject(path: Path)
+                              (implicit l: Logger): IO[Map[String, MD5Hash]] =
     for {
-      md5 <- MD5HashGenerator.md5File(file)
-      etag <- ETagGenerator.eTag(file).map(MD5Hash(_))
+      md5 <- MD5HashGenerator.md5File(path)
+      etag <- ETagGenerator.eTag(path).map(MD5Hash(_))
     } yield Map(
       "md5" -> md5,
       "etag" -> etag

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/ETagGeneratorTest.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/ETagGeneratorTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.FunSpec
 class ETagGeneratorTest extends FunSpec {
 
   private val bigFile = Resource(this, "big-file")
+  private val bigFilePath = bigFile.toPath
   private val configuration = new TransferManagerConfiguration
   private val chunkSize = 1200000
   configuration.setMinimumUploadPartSize(chunkSize)
@@ -35,7 +36,7 @@ class ETagGeneratorTest extends FunSpec {
         "8a0c1d0778ac8fcf4ca2010eba4711eb"
       ).zipWithIndex
       md5Hashes.foreach { case (hash, index) =>
-        test(hash, ETagGenerator.hashChunk(bigFile, index, chunkSize)(logger).unsafeRunSync)
+        test(hash, ETagGenerator.hashChunk(bigFilePath, index, chunkSize)(logger).unsafeRunSync)
       }
     }
   }
@@ -43,7 +44,7 @@ class ETagGeneratorTest extends FunSpec {
   describe("create etag for whole file") {
     val expected = "f14327c90ad105244c446c498bfe9a7d-2"
     it("should match aws etag for the file") {
-      val result = ETagGenerator.eTag(bigFile)(logger).unsafeRunSync
+      val result = ETagGenerator.eTag(bigFilePath)(logger).unsafeRunSync
       assertResult(expected)(result)
     }
   }

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/S3StorageServiceSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/S3StorageServiceSuite.scala
@@ -20,7 +20,7 @@ class S3StorageServiceSuite
     val source = Resource(this, "upload")
     val sourcePath = source.toPath
     val prefix = RemoteKey("prefix")
-    implicit val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
+    implicit val config: Config = Config(Bucket("bucket"), prefix, sources = Sources(List(sourcePath)))
     implicit val implLogger: Logger = new DummyLogger
 
     val lm = LastModified(Instant.now.truncatedTo(ChronoUnit.MILLIS))

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/S3StorageServiceSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/S3StorageServiceSuite.scala
@@ -18,8 +18,9 @@ class S3StorageServiceSuite
 
   describe("listObjectsInPrefix") {
     val source = Resource(this, "upload")
+    val sourcePath = source.toPath
     val prefix = RemoteKey("prefix")
-    implicit val config: Config = Config(Bucket("bucket"), prefix, source = source)
+    implicit val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
     implicit val implLogger: Logger = new DummyLogger
 
     val lm = LastModified(Instant.now.truncatedTo(ChronoUnit.MILLIS))

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
@@ -18,19 +18,20 @@ class StorageServiceSuite
     with MockFactory {
 
   val source = Resource(this, "upload")
+  val sourcePath = source.toPath
 
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
   implicit private val implLogger: Logger = new DummyLogger
   private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
 
   describe("getS3Status") {
     val hash = MD5Hash("hash")
-    val localFile = LocalFile.resolve("the-file", md5HashMap(hash), source, fileToKey)
+    val localFile = LocalFile.resolve("the-file", md5HashMap(hash), sourcePath, fileToKey)
     val key = localFile.remoteKey
-    val keyOtherKey = LocalFile.resolve("other-key-same-hash", md5HashMap(hash), source, fileToKey)
+    val keyOtherKey = LocalFile.resolve("other-key-same-hash", md5HashMap(hash), sourcePath, fileToKey)
     val diffHash = MD5Hash("diff")
-    val keyDiffHash = LocalFile.resolve("other-key-diff-hash", md5HashMap(diffHash), source, fileToKey)
+    val keyDiffHash = LocalFile.resolve("other-key-diff-hash", md5HashMap(diffHash), sourcePath, fileToKey)
     val lastModified = LastModified(Instant.now)
     val s3ObjectsData: S3ObjectsData = S3ObjectsData(
       byHash = Map(
@@ -70,7 +71,7 @@ class StorageServiceSuite
     }
 
     describe("when remote key does not exist and no others matches hash") {
-      val localFile = LocalFile.resolve("missing-file", md5HashMap(MD5Hash("unique")), source, fileToKey)
+      val localFile = LocalFile.resolve("missing-file", md5HashMap(MD5Hash("unique")), sourcePath, fileToKey)
       it("should return no matches by key") {
         val result = getMatchesByKey(invoke(localFile))
         assert(result.isEmpty)
@@ -113,7 +114,7 @@ class StorageServiceSuite
 
       val prefix = RemoteKey("prefix")
       val localFile =
-        LocalFile.resolve("root-file", md5HashMap(Root.hash), source, KeyGenerator.generateKey(source, prefix))
+        LocalFile.resolve("root-file", md5HashMap(Root.hash), sourcePath, KeyGenerator.generateKey(sourcePath, prefix))
       val bucket = Bucket("a-bucket")
       val remoteKey = RemoteKey("prefix/root-file")
       val uploadEventListener = new UploadEventListener(localFile, 1, SyncTotals(), 0L)

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
@@ -21,9 +21,9 @@ class StorageServiceSuite
   val sourcePath = source.toPath
 
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, sources = Sources(List(sourcePath)))
   implicit private val implLogger: Logger = new DummyLogger
-  private val fileToKey = KeyGenerator.generateKey(config.source, config.prefix) _
+  private val fileToKey = KeyGenerator.generateKey(config.sources, config.prefix) _
 
   describe("getS3Status") {
     val hash = MD5Hash("hash")
@@ -114,7 +114,7 @@ class StorageServiceSuite
 
       val prefix = RemoteKey("prefix")
       val localFile =
-        LocalFile.resolve("root-file", md5HashMap(Root.hash), sourcePath, KeyGenerator.generateKey(sourcePath, prefix))
+        LocalFile.resolve("root-file", md5HashMap(Root.hash), sourcePath, KeyGenerator.generateKey(config.sources, prefix))
       val bucket = Bucket("a-bucket")
       val remoteKey = RemoteKey("prefix/root-file")
       val uploadEventListener = new UploadEventListener(localFile, 1, SyncTotals(), 0L)

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
@@ -16,8 +16,9 @@ class UploaderSuite
     with MockFactory {
 
   private val source = Resource(this, ".")
+  private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = source)
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
   implicit private val implLogger: Logger = new DummyLogger
   private val fileToKey = generateKey(config.source, config.prefix) _
   val lastModified = LastModified(Instant.now())
@@ -38,7 +39,7 @@ class UploaderSuite
       // dies when putObject is called
       val returnedKey = RemoteKey("returned-key")
       val returnedHash = MD5Hash("returned-hash")
-      val bigFile = LocalFile.resolve("small-file", md5HashMap(MD5Hash("the-hash")), source, fileToKey)
+      val bigFile = LocalFile.resolve("small-file", md5HashMap(MD5Hash("the-hash")), sourcePath, fileToKey)
       val uploadEventListener = new UploadEventListener(bigFile, 1, SyncTotals(), 0L)
       val amazonS3 = mock[AmazonS3]
       val amazonS3TransferManager = TransferManagerBuilder.standard().withS3Client(amazonS3).build

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderSuite.scala
@@ -18,9 +18,9 @@ class UploaderSuite
   private val source = Resource(this, ".")
   private val sourcePath = source.toPath
   private val prefix = RemoteKey("prefix")
-  implicit private val config: Config = Config(Bucket("bucket"), prefix, source = sourcePath)
+  implicit private val config: Config = Config(Bucket("bucket"), prefix, sources = Sources(List(sourcePath)))
   implicit private val implLogger: Logger = new DummyLogger
-  private val fileToKey = generateKey(config.source, config.prefix) _
+  private val fileToKey = generateKey(config.sources, config.prefix) _
   val lastModified = LastModified(Instant.now())
 
   def md5HashMap(hash: MD5Hash): Map[String, MD5Hash] =


### PR DESCRIPTION
Given two or more trees that need to be synced to S3, where the trees need to be merged. The tress would be listed in priority order, such that if a file exists in both trees, the file in the higher priority tree is uploaded to S3.

e.g.
``` bash
s3thorp -b my-bucket -p my/prefix -s tree1,tree2,tree3
```
Would upload the contents of `tree1`, `tree2` and `tree3` int `s3://my-bucket/my/prefix`, such that the files `tree1/alpha`, `tree2/beta`, `tree2/alpha` and `tree3/gamma` would map to `my/prefix/alpha`, `my/prefix/beta`, and `my/prefix/gamma`. The `tree1/alpha` file would be uploaded, and `tree2/alpha` would be ignored. 