### PR TITLE
NullPointerException creating scaladoc

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,6 +6,18 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 [[https://semver.org/spec/v2.0.0.html][Semantic Versioning]].
 
 
+* [0.7.2] - 2019-07-19
+
+** Changed
+
+   - Apply ~scalafmt~ (#108)
+   - Uses Lenses (#113)
+
+** Fixed
+
+   - Creates incorrect MD5 hash for some files (#103)
+   - NullPointerException creating scaladoc (#115)
+
 * [0.7.1] - 2019-07-15
 
 ** Changed

--- a/build.sbt
+++ b/build.sbt
@@ -26,9 +26,6 @@ val commonSettings = Seq(
     "-language:postfixOps",
     "-language:higherKinds",
     "-Ypartial-unification"),
-  addCompilerPlugin(
-    "org.scalameta" % "paradise" % "3.0.0-M11" cross CrossVersion.full
-  ),
   test in assembly := {}
 )
 

--- a/core/src/main/scala/net/kemitix/thorp/core/Action.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Action.scala
@@ -1,6 +1,5 @@
 package net.kemitix.thorp.core
 
-import monocle.macros.Lenses
 import net.kemitix.thorp.domain.{Bucket, LocalFile, MD5Hash, RemoteKey}
 
 sealed trait Action {
@@ -9,21 +8,18 @@ sealed trait Action {
 }
 object Action {
 
-  @Lenses
   final case class DoNothing(
       bucket: Bucket,
       remoteKey: RemoteKey,
       size: Long
   ) extends Action
 
-  @Lenses
   final case class ToUpload(
       bucket: Bucket,
       localFile: LocalFile,
       size: Long
   ) extends Action
 
-  @Lenses
   final case class ToCopy(
       bucket: Bucket,
       sourceKey: RemoteKey,
@@ -32,7 +28,6 @@ object Action {
       size: Long
   ) extends Action
 
-  @Lenses
   final case class ToDelete(
       bucket: Bucket,
       remoteKey: RemoteKey,

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigOption.scala
@@ -2,7 +2,6 @@ package net.kemitix.thorp.core
 
 import java.nio.file.Path
 
-import monocle.macros.Lenses
 import net.kemitix.thorp.domain
 import net.kemitix.thorp.domain.{Config, RemoteKey}
 import net.kemitix.thorp.domain.Config._
@@ -13,13 +12,11 @@ sealed trait ConfigOption {
 
 object ConfigOption {
 
-  @Lenses
   case class Source(path: Path) extends ConfigOption {
     override def update(config: Config): Config =
       sources.modify(_ ++ path)(config)
   }
 
-  @Lenses
   case class Bucket(name: String) extends ConfigOption {
     override def update(config: Config): Config =
       if (config.bucket.name.isEmpty)
@@ -28,7 +25,6 @@ object ConfigOption {
         config
   }
 
-  @Lenses
   case class Prefix(path: String) extends ConfigOption {
     override def update(config: Config): Config =
       if (config.prefix.key.isEmpty)
@@ -37,19 +33,16 @@ object ConfigOption {
         config
   }
 
-  @Lenses
   case class Include(pattern: String) extends ConfigOption {
     override def update(config: Config): Config =
       filters.modify(domain.Filter.Include(pattern) :: _)(config)
   }
 
-  @Lenses
   case class Exclude(pattern: String) extends ConfigOption {
     override def update(config: Config): Config =
       filters.modify(domain.Filter.Exclude(pattern) :: _)(config)
   }
 
-  @Lenses
   case class Debug() extends ConfigOption {
     override def update(config: Config): Config =
       debug.set(true)(config)

--- a/core/src/main/scala/net/kemitix/thorp/core/ConfigOptions.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ConfigOptions.scala
@@ -1,9 +1,9 @@
 package net.kemitix.thorp.core
 
 import cats.Semigroup
-import monocle.macros.Lenses
+import monocle.Lens
+import monocle.macros.GenLens
 
-@Lenses
 case class ConfigOptions(
     options: List[ConfigOption] = List()
 ) extends Semigroup[ConfigOptions] {
@@ -23,4 +23,9 @@ case class ConfigOptions(
   def contains[A1 >: ConfigOption](elem: A1): Boolean =
     options contains elem
 
+}
+
+object ConfigOptions {
+  val options: Lens[ConfigOptions, List[ConfigOption]] =
+    GenLens[ConfigOptions](_.options)
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/Counters.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/Counters.scala
@@ -1,11 +1,18 @@
 package net.kemitix.thorp.core
 
-import monocle.macros.Lenses
+import monocle.Lens
+import monocle.macros.GenLens
 
-@Lenses
 final case class Counters(
     uploaded: Int = 0,
     deleted: Int = 0,
     copied: Int = 0,
     errors: Int = 0
 )
+
+object Counters {
+  val uploaded: Lens[Counters, Int] = GenLens[Counters](_.uploaded)
+  val deleted: Lens[Counters, Int]  = GenLens[Counters](_.deleted)
+  val copied: Lens[Counters, Int]   = GenLens[Counters](_.copied)
+  val errors: Lens[Counters, Int]   = GenLens[Counters](_.errors)
+}

--- a/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/LocalFiles.scala
@@ -1,9 +1,7 @@
 package net.kemitix.thorp.core
 
-import monocle.macros.Lenses
 import net.kemitix.thorp.domain.LocalFile
 
-@Lenses
 case class LocalFiles(
     localFiles: Stream[LocalFile] = Stream(),
     count: Long = 0,

--- a/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SyncPlan.scala
@@ -1,9 +1,7 @@
 package net.kemitix.thorp.core
 
-import monocle.macros.Lenses
 import net.kemitix.thorp.domain.SyncTotals
 
-@Lenses
 case class SyncPlan(
     actions: Stream[Action] = Stream(),
     syncTotals: SyncTotals = SyncTotals()

--- a/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
@@ -1,20 +1,11 @@
 package net.kemitix.thorp.core
 
 import cats.effect.IO
-import monocle.macros.Lenses
 import net.kemitix.thorp.core.Action.{DoNothing, ToCopy, ToDelete, ToUpload}
 import net.kemitix.thorp.domain.StorageQueueEvent.DoNothingQueueEvent
-import net.kemitix.thorp.domain.{
-  Bucket,
-  LocalFile,
-  Logger,
-  StorageQueueEvent,
-  SyncTotals,
-  UploadEventListener
-}
+import net.kemitix.thorp.domain._
 import net.kemitix.thorp.storage.api.StorageService
 
-@Lenses
 case class UnversionedMirrorArchive(
     storageService: StorageService,
     batchMode: Boolean,

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Bucket.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Bucket.scala
@@ -1,8 +1,5 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
-@Lenses
 final case class Bucket(
     name: String
 )

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Config.scala
@@ -1,8 +1,8 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
+import monocle.Lens
+import monocle.macros.GenLens
 
-@Lenses
 final case class Config(
     bucket: Bucket = Bucket(""),
     prefix: RemoteKey = RemoteKey(""),
@@ -11,3 +11,12 @@ final case class Config(
     batchMode: Boolean = false,
     sources: Sources = Sources(List())
 )
+
+object Config {
+  val sources: Lens[Config, Sources]      = GenLens[Config](_.sources)
+  val bucket: Lens[Config, Bucket]        = GenLens[Config](_.bucket)
+  val prefix: Lens[Config, RemoteKey]     = GenLens[Config](_.prefix)
+  val filters: Lens[Config, List[Filter]] = GenLens[Config](_.filters)
+  val debug: Lens[Config, Boolean]        = GenLens[Config](_.debug)
+  val batchMode: Lens[Config, Boolean]    = GenLens[Config](_.batchMode)
+}

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Filter.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Filter.scala
@@ -3,8 +3,6 @@ package net.kemitix.thorp.domain
 import java.nio.file.Path
 import java.util.regex.Pattern
 
-import monocle.macros.Lenses
-
 sealed trait Filter
 
 object Filter {
@@ -32,7 +30,6 @@ object Filter {
     }
   }
 
-  @Lenses
   case class Include(
       include: String = ".*"
   ) extends Filter {
@@ -43,7 +40,6 @@ object Filter {
 
   }
 
-  @Lenses
   case class Exclude(
       exclude: String
   ) extends Filter {

--- a/domain/src/main/scala/net/kemitix/thorp/domain/HashModified.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/HashModified.scala
@@ -1,8 +1,5 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
-@Lenses
 final case class HashModified(
     hash: MD5Hash,
     modified: LastModified

--- a/domain/src/main/scala/net/kemitix/thorp/domain/KeyModified.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/KeyModified.scala
@@ -1,8 +1,5 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
-@Lenses
 final case class KeyModified(
     key: RemoteKey,
     modified: LastModified

--- a/domain/src/main/scala/net/kemitix/thorp/domain/LastModified.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/LastModified.scala
@@ -2,9 +2,6 @@ package net.kemitix.thorp.domain
 
 import java.time.Instant
 
-import monocle.macros.Lenses
-
-@Lenses
 final case class LastModified(
     when: Instant = Instant.now
 )

--- a/domain/src/main/scala/net/kemitix/thorp/domain/LocalFile.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/LocalFile.scala
@@ -3,9 +3,9 @@ package net.kemitix.thorp.domain
 import java.io.File
 import java.nio.file.Path
 
-import monocle.macros.Lenses
+import monocle.Lens
+import monocle.macros.GenLens
 
-@Lenses
 final case class LocalFile(
     file: File,
     source: File,
@@ -41,4 +41,5 @@ object LocalFile {
               pathToKey(resolvedPath))
   }
 
+  val remoteKey: Lens[LocalFile, RemoteKey] = GenLens[LocalFile](_.remoteKey)
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/MD5Hash.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/MD5Hash.scala
@@ -4,9 +4,6 @@ import java.util.Base64
 
 import net.kemitix.thorp.domain.QuoteStripper.stripQuotes
 
-import monocle.macros.Lenses
-
-@Lenses
 final case class MD5Hash(
     in: String
 ) {

--- a/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/RemoteKey.scala
@@ -3,9 +3,8 @@ package net.kemitix.thorp.domain
 import java.io.File
 import java.nio.file.{Path, Paths}
 
-import monocle.macros.Lenses
+import monocle.macros.GenLens
 
-@Lenses
 final case class RemoteKey(
     key: String
 ) {
@@ -37,4 +36,8 @@ final case class RemoteKey(
   def resolve(path: String): RemoteKey =
     RemoteKey(List(key, path).filterNot(_.isEmpty).mkString("/"))
 
+}
+
+object RemoteKey {
+  val key = GenLens[RemoteKey](_.key)
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/RemoteMetaData.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/RemoteMetaData.scala
@@ -1,8 +1,5 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
-@Lenses
 final case class RemoteMetaData(
     remoteKey: RemoteKey,
     hash: MD5Hash,

--- a/domain/src/main/scala/net/kemitix/thorp/domain/S3MetaData.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/S3MetaData.scala
@@ -1,9 +1,6 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
 // For the LocalFile, the set of matching S3 objects with the same MD5Hash, and any S3 object with the same remote key
-@Lenses
 final case class S3MetaData(
     localFile: LocalFile,
     matchByHash: Set[RemoteMetaData],

--- a/domain/src/main/scala/net/kemitix/thorp/domain/S3ObjectsData.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/S3ObjectsData.scala
@@ -1,12 +1,8 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
 /**
   * A list of objects and their MD5 hash values.
   */
-
-@Lenses
 final case class S3ObjectsData(
     byHash: Map[MD5Hash, Set[KeyModified]] = Map.empty,
     byKey: Map[RemoteKey, HashModified] = Map.empty

--- a/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/Sources.scala
@@ -2,8 +2,6 @@ package net.kemitix.thorp.domain
 
 import java.nio.file.Path
 
-import monocle.macros.Lenses
-
 /**
   * The paths to synchronise with target.
   *
@@ -14,7 +12,6 @@ import monocle.macros.Lenses
   *
   * A path should only occur once in paths.
   */
-@Lenses
 case class Sources(
     paths: List[Path]
 ) {

--- a/domain/src/main/scala/net/kemitix/thorp/domain/StorageQueueEvent.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/StorageQueueEvent.scala
@@ -1,7 +1,5 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
 sealed trait StorageQueueEvent {
 
   val order: Int
@@ -10,21 +8,18 @@ sealed trait StorageQueueEvent {
 
 object StorageQueueEvent {
 
-  @Lenses
   final case class DoNothingQueueEvent(
       remoteKey: RemoteKey
   ) extends StorageQueueEvent {
     override val order: Int = 0
   }
 
-  @Lenses
   final case class CopyQueueEvent(
       remoteKey: RemoteKey
   ) extends StorageQueueEvent {
     override val order: Int = 1
   }
 
-  @Lenses
   final case class UploadQueueEvent(
       remoteKey: RemoteKey,
       md5Hash: MD5Hash
@@ -32,14 +27,12 @@ object StorageQueueEvent {
     override val order: Int = 2
   }
 
-  @Lenses
   final case class DeleteQueueEvent(
       remoteKey: RemoteKey
   ) extends StorageQueueEvent {
     override val order: Int = 3
   }
 
-  @Lenses
   final case class ErrorQueueEvent(
       remoteKey: RemoteKey,
       e: Throwable
@@ -47,7 +40,6 @@ object StorageQueueEvent {
     override val order: Int = 10
   }
 
-  @Lenses
   final case class ShutdownQueueEvent() extends StorageQueueEvent {
     override val order: Int = 99
   }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/SyncTotals.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/SyncTotals.scala
@@ -1,8 +1,5 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
-@Lenses
 case class SyncTotals(
     count: Long = 0L,
     totalSizeBytes: Long = 0L,

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEvent.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEvent.scala
@@ -1,26 +1,21 @@
 package net.kemitix.thorp.domain
 
-import monocle.macros.Lenses
-
 sealed trait UploadEvent {
   def name: String
 }
 
 object UploadEvent {
 
-  @Lenses
   final case class TransferEvent(
       name: String
   ) extends UploadEvent
 
-  @Lenses
   final case class RequestEvent(
       name: String,
       bytes: Long,
       transferred: Long
   ) extends UploadEvent
 
-  @Lenses
   final case class ByteTransferEvent(
       name: String
   ) extends UploadEvent

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
@@ -3,9 +3,6 @@ package net.kemitix.thorp.domain
 import net.kemitix.thorp.domain.UploadEvent.RequestEvent
 import net.kemitix.thorp.domain.UploadEventLogger.logRequestCycle
 
-import monocle.macros.Lenses
-
-@Lenses
 case class UploadEventListener(
     localFile: LocalFile,
     index: Int,


### PR DESCRIPTION
Since adding the `@Lenses` annotation the `sbt ci-release` command fails with an NPE while creating scaladoc:
```
[error] java.lang.NullPointerException
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.callToCompanionConstr(Typers.scala:3425)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.tryNamesDefaults$1(Typers.scala:3688)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.doTypedApply(Typers.scala:3711)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.normalTypedApply$1(Typers.scala:4876)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedApply$1(Typers.scala:4885)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5680)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5726)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedAnnotation(Typers.scala:3988)
[error] 	at scala.tools.nsc.typechecker.Namers$Namer.$anonfun$annotSig$4(Namers.scala:1860)
[error] 	at scala.tools.nsc.typechecker.Namers$Namer.$anonfun$annotSig$3(Namers.scala:1860)
[error] 	at scala.reflect.internal.AnnotationInfos$LazyAnnotationInfo.forcedInfo$lzycompute(AnnotationInfos.scala:224)
[error] 	at scala.reflect.internal.AnnotationInfos$LazyAnnotationInfo.forcedInfo(AnnotationInfos.scala:224)
[error] 	at scala.reflect.internal.AnnotationInfos$LazyAnnotationInfo.completeInfo(AnnotationInfos.scala:237)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedTemplate$2(Typers.scala:1975)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedTemplate(Typers.scala:1975)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedClassDef(Typers.scala:1843)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5646)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5726)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:5790)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3373)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3373)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedTemplate(Typers.scala:2030)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedModuleDef(Typers.scala:1896)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5647)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5726)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:5790)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3373)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3373)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typedPackageDef$1(Typers.scala:5356)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5649)
[error] 	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5726)
[error] 	at scala.tools.nsc.typechecker.Analyzer$typerFactory$TyperPhase.apply(Analyzer.scala:114)
[error] 	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:448)
[error] 	at scala.tools.nsc.typechecker.Analyzer$typerFactory$TyperPhase.run(Analyzer.scala:103)
[error] 	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1498)
[error] 	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1482)
[error] 	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1475)
[error] 	at scala.tools.nsc.Global$Run.compile(Global.scala:1598)
[error] 	at scala.tools.nsc.doc.DocFactory.makeUniverse(DocFactory.scala:51)
[error] 	at scala.tools.nsc.doc.DocFactory.generate$1(DocFactory.scala:131)
[error] 	at scala.tools.nsc.doc.DocFactory.document(DocFactory.scala:138)
[error] 	at xsbt.Runner.run(ScaladocInterface.scala:30)
[error] 	at xsbt.ScaladocInterface.run(ScaladocInterface.scala:15)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.lang.reflect.Method.invoke(Method.java:498)
[error] 	at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:237)
[error] 	at sbt.internal.inc.AnalyzingCompiler.doc(AnalyzingCompiler.scala:166)
[error] 	at sbt.internal.inc.AnalyzingCompiler.doc(AnalyzingCompiler.scala:147)
[error] 	at sbt.Doc$.$anonfun$scaladoc$1(Doc.scala:39)
[error] 	at sbt.Doc$.$anonfun$scaladoc$1$adapted(Doc.scala:39)
[error] 	at sbt.RawCompileLike$.$anonfun$prepare$1(RawCompileLike.scala:83)
[error] 	at sbt.RawCompileLike$.$anonfun$prepare$1$adapted(RawCompileLike.scala:76)
[error] 	at sbt.RawCompileLike$.$anonfun$cached$3(RawCompileLike.scala:67)
[error] 	at sbt.RawCompileLike$.$anonfun$cached$3$adapted(RawCompileLike.scala:65)
[error] 	at sbt.util.Tracked$.$anonfun$inputChanged$1(Tracked.scala:149)
[error] 	at sbt.RawCompileLike$.$anonfun$cached$1(RawCompileLike.scala:72)
[error] 	at sbt.RawCompileLike$.$anonfun$cached$1$adapted(RawCompileLike.scala:55)
[error] 	at sbt.Defaults$.$anonfun$docTaskSettings$3(Defaults.scala:1427)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
```