### PR TITLE
Ensure file handles are always closed

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -12,6 +12,7 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 
    - Log copy and delete operations (#119)
    - Log errors with red label (#119)
+   - Ensure file handles are always closed (#122)
 
 ** Changed
 


### PR DESCRIPTION
Add better guarantees that files being read by the `MD5HashGenerator` are always closed properly.