### PR TITLE
Refactor Uploader.upload(LocalFile,Bucket,Boolean,UploadEventListener,Int)

### DIFF
--- a/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
@@ -36,8 +36,7 @@ case class UnversionedMirrorArchive(syncTotals: SyncTotals)
     Storage.upload(
       localFile,
       bucket,
-      UploadEventListener(localFile, index, syncTotals, totalBytesSoFar),
-      1)
+      UploadEventListener(localFile, index, syncTotals, totalBytesSoFar))
 }
 
 object UnversionedMirrorArchive {

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
@@ -20,10 +20,11 @@ case class DummyStorageService(s3ObjectData: S3ObjectsData,
   ): TaskR[Console, S3ObjectsData] =
     TaskR(s3ObjectData)
 
-  override def upload(localFile: LocalFile,
-                      bucket: Bucket,
-                      uploadEventListener: UploadEventListener,
-                      tryCount: Int): UIO[StorageQueueEvent] = {
+  override def upload(
+      localFile: LocalFile,
+      bucket: Bucket,
+      uploadEventListener: UploadEventListener,
+  ): UIO[StorageQueueEvent] = {
     val (remoteKey, md5Hash) = uploadFiles(localFile.file)
     UIO(StorageQueueEvent.UploadQueueEvent(remoteKey, md5Hash))
   }

--- a/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
+++ b/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
@@ -21,7 +21,6 @@ object Storage {
         localFile: LocalFile,
         bucket: Bucket,
         uploadEventListener: UploadEventListener,
-        tryCount: Int
     ): ZIO[Storage with Config, Nothing, StorageQueueEvent]
 
     def copy(
@@ -57,8 +56,8 @@ object Storage {
       override def upload(
           localFile: LocalFile,
           bucket: Bucket,
-          uploadEventListener: UploadEventListener,
-          tryCount: Int): ZIO[Storage, Nothing, StorageQueueEvent] =
+          uploadEventListener: UploadEventListener
+      ): ZIO[Storage, Nothing, StorageQueueEvent] =
         uploadResult
 
       override def copy(
@@ -99,11 +98,9 @@ object Storage {
   final def upload(
       localFile: LocalFile,
       bucket: Bucket,
-      uploadEventListener: UploadEventListener,
-      tryCount: Int
+      uploadEventListener: UploadEventListener
   ): ZIO[Storage with Config, Nothing, StorageQueueEvent] =
-    ZIO.accessM(
-      _.storage upload (localFile, bucket, uploadEventListener, tryCount))
+    ZIO.accessM(_.storage upload (localFile, bucket, uploadEventListener))
 
   final def copy(
       bucket: Bucket,

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
@@ -29,7 +29,8 @@ object S3Storage {
           bucket: Bucket,
           uploadEventListener: UploadEventListener,
       ): ZIO[Config, Nothing, StorageQueueEvent] =
-        Uploader.upload(transferManager)(localFile, bucket, uploadEventListener)
+        Uploader.upload(transferManager)(
+          Uploader.Request(localFile, bucket, uploadEventListener))
 
       override def copy(bucket: Bucket,
                         sourceKey: RemoteKey,

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
@@ -28,11 +28,8 @@ object S3Storage {
           localFile: LocalFile,
           bucket: Bucket,
           uploadEventListener: UploadEventListener,
-          tryCount: Int): ZIO[Config, Nothing, StorageQueueEvent] =
-        Uploader.upload(transferManager)(localFile,
-                                         bucket,
-                                         uploadEventListener,
-                                         1)
+      ): ZIO[Config, Nothing, StorageQueueEvent] =
+        Uploader.upload(transferManager)(localFile, bucket, uploadEventListener)
 
       override def copy(bucket: Bucket,
                         sourceKey: RemoteKey,

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Uploader.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Uploader.scala
@@ -21,8 +21,7 @@ trait Uploader {
   def upload(transferManager: => AmazonTransferManager)(
       localFile: LocalFile,
       bucket: Bucket,
-      uploadEventListener: UploadEventListener,
-      tryCount: Int
+      uploadEventListener: UploadEventListener
   ): ZIO[Config, Nothing, StorageQueueEvent] =
     transfer(transferManager)(localFile, bucket, uploadEventListener)
       .catchAll(handleError(localFile.remoteKey))

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
@@ -25,28 +25,32 @@ trait AmazonS3ClientTestFixture extends MockFactory {
 
         override def listObjects(
             bucket: Bucket,
-            prefix: RemoteKey): TaskR[Console, S3ObjectsData] =
+            prefix: RemoteKey
+        ): TaskR[Console, S3ObjectsData] =
           Lister.listObjects(client)(bucket, prefix)
 
         override def upload(
             localFile: LocalFile,
             bucket: Bucket,
             uploadEventListener: UploadEventListener,
-            tryCount: Int): ZIO[Config, Nothing, StorageQueueEvent] =
+        ): ZIO[Config, Nothing, StorageQueueEvent] =
           Uploader.upload(transferManager)(localFile,
                                            bucket,
-                                           uploadEventListener,
-                                           1)
+                                           uploadEventListener)
 
-        override def copy(bucket: Bucket,
-                          sourceKey: RemoteKey,
-                          hash: MD5Hash,
-                          targetKey: RemoteKey): UIO[StorageQueueEvent] =
+        override def copy(
+            bucket: Bucket,
+            sourceKey: RemoteKey,
+            hash: MD5Hash,
+            targetKey: RemoteKey
+        ): UIO[StorageQueueEvent] =
           Copier.copy(client)(
             Copier.Request(bucket, sourceKey, hash, targetKey))
 
-        override def delete(bucket: Bucket,
-                            remoteKey: RemoteKey): UIO[StorageQueueEvent] =
+        override def delete(
+            bucket: Bucket,
+            remoteKey: RemoteKey
+        ): UIO[StorageQueueEvent] =
           Deleter.delete(client)(bucket, remoteKey)
 
         override def shutdown: UIO[StorageQueueEvent] = {

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
@@ -34,9 +34,8 @@ trait AmazonS3ClientTestFixture extends MockFactory {
             bucket: Bucket,
             uploadEventListener: UploadEventListener,
         ): ZIO[Config, Nothing, StorageQueueEvent] =
-          Uploader.upload(transferManager)(localFile,
-                                           bucket,
-                                           uploadEventListener)
+          Uploader.upload(transferManager)(
+            Uploader.Request(localFile, bucket, uploadEventListener))
 
         override def copy(
             bucket: Bucket,

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderTest.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderTest.scala
@@ -96,7 +96,8 @@ class UploaderTest extends FreeSpec with MockFactory {
       val testEnv: TestEnv = Config.Live
       new DefaultRuntime {}.unsafeRunSync {
         Uploader
-          .upload(transferManager)(localFile, bucket, uploadEventListener)
+          .upload(transferManager)(
+            Uploader.Request(localFile, bucket, uploadEventListener))
           .provide(testEnv)
       }.toEither
     }

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderTest.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderTest.scala
@@ -27,7 +27,6 @@ class UploaderTest extends FreeSpec with MockFactory {
     val remoteKey     = RemoteKey("aRemoteKey")
     val localFile     = LocalFile(aFile, aSource, hashes, remoteKey)
     val bucket        = Bucket("aBucket")
-    val tryCount      = 1
     val uploadResult  = new UploadResult
     uploadResult.setKey(remoteKey.key)
     uploadResult.setETag(aHash.hash)
@@ -47,8 +46,7 @@ class UploaderTest extends FreeSpec with MockFactory {
           invoke(fixture.amazonS3TransferManager)(
             localFile,
             bucket,
-            uploadEventListener,
-            tryCount
+            uploadEventListener
           )
         assertResult(expected)(result)
       }
@@ -66,8 +64,7 @@ class UploaderTest extends FreeSpec with MockFactory {
           invoke(fixture.amazonS3TransferManager)(
             localFile,
             bucket,
-            uploadEventListener,
-            tryCount
+            uploadEventListener
           )
         assertResult(expected)(result)
       }
@@ -85,8 +82,7 @@ class UploaderTest extends FreeSpec with MockFactory {
           invoke(fixture.amazonS3TransferManager)(
             localFile,
             bucket,
-            uploadEventListener,
-            tryCount
+            uploadEventListener
           )
         assertResult(expected)(result)
       }
@@ -94,19 +90,13 @@ class UploaderTest extends FreeSpec with MockFactory {
     def invoke(transferManager: AmazonTransferManager)(
         localFile: LocalFile,
         bucket: Bucket,
-        uploadEventListener: UploadEventListener,
-        tryCount: Int
+        uploadEventListener: UploadEventListener
     ) = {
       type TestEnv = Config
       val testEnv: TestEnv = Config.Live
       new DefaultRuntime {}.unsafeRunSync {
         Uploader
-          .upload(transferManager)(
-            localFile,
-            bucket,
-            uploadEventListener,
-            tryCount
-          )
+          .upload(transferManager)(localFile, bucket, uploadEventListener)
           .provide(testEnv)
       }.toEither
     }


### PR DESCRIPTION
I've selected [**Uploader.upload(LocalFile,Bucket,Boolean,UploadEventListener,Int)**](https://github.com/kemitix/thorp/blob/985cc9f1476567f860d4e98e055ab2c10cd077d8/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Uploader.scala#L20-L29) for refactoring, which is a unit of **3** lines of code and **5** parameters. Addressing this will make our codebase more maintainable and improve [Better Code Hub](https://bettercodehub.com)'s **Keep Unit Interfaces Small** guideline rating! 👍 

Here's the gist of this guideline:
- **Definition** 📖 
Limit the number of parameters per unit to at most 4.
- **Why**❓ 
Keeping the number of parameters low makes units easier to understand, test and reuse.
- **How** 🔧 
Reduce the number of parameters by grouping related parameters into objects. Alternatively, try extracting parts of units that require fewer parameters.

You can find more info about this guideline in [Building Maintainable Software](http://shop.oreilly.com/product/0636920049159.do). 📖 
 
---- 
ℹ️ To know how many _other_ refactoring candidates need addressing to get a guideline compliant, select some by clicking on the 🔲  next to them. The risk profile below the candidates signals (✅) when it's enough! 🏁 


----
Good luck and happy coding! :shipit: :sparkles: :100: