### PR TITLE
Refactor UploadEventLogger.statusWithBar(String,Long=>String,Long,Long,Long)

### DIFF
--- a/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/UnversionedMirrorArchive.scala
@@ -33,10 +33,12 @@ case class UnversionedMirrorArchive(syncTotals: SyncTotals)
       bucket: Bucket,
       localFile: LocalFile
   ) =
-    Storage.upload(
-      localFile,
-      bucket,
-      UploadEventListener(localFile, index, syncTotals, totalBytesSoFar))
+    Storage.upload(localFile,
+                   bucket,
+                   UploadEventListener.Settings(localFile,
+                                                index,
+                                                syncTotals,
+                                                totalBytesSoFar))
 }
 
 object UnversionedMirrorArchive {

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
@@ -23,7 +23,7 @@ case class DummyStorageService(s3ObjectData: S3ObjectsData,
   override def upload(
       localFile: LocalFile,
       bucket: Bucket,
-      uploadEventListener: UploadEventListener,
+      uploadEventListener: UploadEventListener.Settings,
   ): UIO[StorageQueueEvent] = {
     val (remoteKey, md5Hash) = uploadFiles(localFile.file)
     UIO(StorageQueueEvent.UploadQueueEvent(remoteKey, md5Hash))

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
@@ -1,7 +1,10 @@
 package net.kemitix.thorp.domain
 
 import net.kemitix.thorp.domain.UploadEvent.RequestEvent
-import net.kemitix.thorp.domain.UploadEventLogger.logRequestCycle
+import net.kemitix.thorp.domain.UploadEventLogger.{
+  RequestCycle,
+  logRequestCycle
+}
 
 case class UploadEventListener(
     localFile: LocalFile,
@@ -15,12 +18,12 @@ case class UploadEventListener(
   def listener: UploadEvent => Unit = {
     case e: RequestEvent =>
       bytesTransferred += e.transferred
-      logRequestCycle(localFile,
-                      e,
-                      bytesTransferred,
-                      index,
-                      syncTotals,
-                      totalBytesSoFar)
+      logRequestCycle(
+        RequestCycle(localFile,
+                     bytesTransferred,
+                     index,
+                     syncTotals,
+                     totalBytesSoFar))
     case _ => ()
   }
 }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventListener.scala
@@ -6,24 +6,27 @@ import net.kemitix.thorp.domain.UploadEventLogger.{
   logRequestCycle
 }
 
-case class UploadEventListener(
-    localFile: LocalFile,
-    index: Int,
-    syncTotals: SyncTotals,
-    totalBytesSoFar: Long
-) {
+object UploadEventListener {
+
+  case class Settings(
+      localFile: LocalFile,
+      index: Int,
+      syncTotals: SyncTotals,
+      totalBytesSoFar: Long
+  )
 
   var bytesTransferred = 0L
 
-  def listener: UploadEvent => Unit = {
+  def listener(settings: Settings): UploadEvent => Unit = {
     case e: RequestEvent =>
       bytesTransferred += e.transferred
       logRequestCycle(
-        RequestCycle(localFile,
+        RequestCycle(settings.localFile,
                      bytesTransferred,
-                     index,
-                     syncTotals,
-                     totalBytesSoFar))
+                     settings.index,
+                     settings.syncTotals,
+                     settings.totalBytesSoFar))
     case _ => ()
   }
+
 }

--- a/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
+++ b/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
@@ -20,7 +20,7 @@ object Storage {
     def upload(
         localFile: LocalFile,
         bucket: Bucket,
-        uploadEventListener: UploadEventListener,
+        listenerSettings: UploadEventListener.Settings,
     ): ZIO[Storage with Config, Nothing, StorageQueueEvent]
 
     def copy(
@@ -56,7 +56,7 @@ object Storage {
       override def upload(
           localFile: LocalFile,
           bucket: Bucket,
-          uploadEventListener: UploadEventListener
+          listenerSettings: UploadEventListener.Settings
       ): ZIO[Storage, Nothing, StorageQueueEvent] =
         uploadResult
 
@@ -98,9 +98,9 @@ object Storage {
   final def upload(
       localFile: LocalFile,
       bucket: Bucket,
-      uploadEventListener: UploadEventListener
+      listenerSettings: UploadEventListener.Settings
   ): ZIO[Storage with Config, Nothing, StorageQueueEvent] =
-    ZIO.accessM(_.storage upload (localFile, bucket, uploadEventListener))
+    ZIO.accessM(_.storage upload (localFile, bucket, listenerSettings))
 
   final def copy(
       bucket: Bucket,

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
@@ -27,10 +27,10 @@ object S3Storage {
       override def upload(
           localFile: LocalFile,
           bucket: Bucket,
-          uploadEventListener: UploadEventListener,
+          listenerSettings: UploadEventListener.Settings,
       ): ZIO[Config, Nothing, StorageQueueEvent] =
         Uploader.upload(transferManager)(
-          Uploader.Request(localFile, bucket, uploadEventListener))
+          Uploader.Request(localFile, bucket, listenerSettings))
 
       override def copy(bucket: Bucket,
                         sourceKey: RemoteKey,

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Uploader.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Uploader.scala
@@ -21,7 +21,7 @@ trait Uploader {
   case class Request(
       localFile: LocalFile,
       bucket: Bucket,
-      uploadEventListener: UploadEventListener
+      uploadEventListener: UploadEventListener.Settings
   )
 
   def upload(transferManager: => AmazonTransferManager)(
@@ -72,11 +72,13 @@ trait Uploader {
     metadata
   }
 
-  private def progressListener: UploadEventListener => ProgressListener =
-    uploadEventListener =>
+  private def progressListener
+    : UploadEventListener.Settings => ProgressListener =
+    listenerSettings =>
       new ProgressListener {
         override def progressChanged(progressEvent: ProgressEvent): Unit =
-          uploadEventListener.listener(eventHandler(progressEvent))
+          UploadEventListener.listener(listenerSettings)(
+            eventHandler(progressEvent))
 
         private def eventHandler: ProgressEvent => UploadEvent =
           progressEvent => {

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
@@ -32,10 +32,10 @@ trait AmazonS3ClientTestFixture extends MockFactory {
         override def upload(
             localFile: LocalFile,
             bucket: Bucket,
-            uploadEventListener: UploadEventListener,
+            listenerSettings: UploadEventListener.Settings,
         ): ZIO[Config, Nothing, StorageQueueEvent] =
           Uploader.upload(transferManager)(
-            Uploader.Request(localFile, bucket, uploadEventListener))
+            Uploader.Request(localFile, bucket, listenerSettings))
 
         override def copy(
             bucket: Bucket,

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderTest.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/UploaderTest.scala
@@ -33,8 +33,8 @@ class UploaderTest extends FreeSpec with MockFactory {
     val inProgress = new AmazonUpload.InProgress {
       override def waitForUploadResult: UploadResult = uploadResult
     }
-    val uploadEventListener =
-      UploadEventListener(localFile, 0, SyncTotals(1, 0, 0), 0)
+    val listenerSettings =
+      UploadEventListener.Settings(localFile, 0, SyncTotals(1, 0, 0), 0)
     "when no error" in {
       val expected =
         Right(UploadQueueEvent(remoteKey, aHash))
@@ -46,7 +46,7 @@ class UploaderTest extends FreeSpec with MockFactory {
           invoke(fixture.amazonS3TransferManager)(
             localFile,
             bucket,
-            uploadEventListener
+            listenerSettings
           )
         assertResult(expected)(result)
       }
@@ -64,7 +64,7 @@ class UploaderTest extends FreeSpec with MockFactory {
           invoke(fixture.amazonS3TransferManager)(
             localFile,
             bucket,
-            uploadEventListener
+            listenerSettings
           )
         assertResult(expected)(result)
       }
@@ -82,7 +82,7 @@ class UploaderTest extends FreeSpec with MockFactory {
           invoke(fixture.amazonS3TransferManager)(
             localFile,
             bucket,
-            uploadEventListener
+            listenerSettings
           )
         assertResult(expected)(result)
       }
@@ -90,14 +90,14 @@ class UploaderTest extends FreeSpec with MockFactory {
     def invoke(transferManager: AmazonTransferManager)(
         localFile: LocalFile,
         bucket: Bucket,
-        uploadEventListener: UploadEventListener
+        listenerSettings: UploadEventListener.Settings
     ) = {
       type TestEnv = Config
       val testEnv: TestEnv = Config.Live
       new DefaultRuntime {}.unsafeRunSync {
         Uploader
           .upload(transferManager)(
-            Uploader.Request(localFile, bucket, uploadEventListener))
+            Uploader.Request(localFile, bucket, listenerSettings))
           .provide(testEnv)
       }.toEither
     }


### PR DESCRIPTION
I've selected [**UploadEventLogger.statusWithBar(String,Long=>String,Long,Long,Long)**](https://github.com/kemitix/thorp/blob/985cc9f1476567f860d4e98e055ab2c10cd077d8/domain/src/main/scala/net/kemitix/thorp/domain/UploadEventLogger.scala#L34-L46) for refactoring, which is a unit of **7** lines of code and **5** parameters. Addressing this will make our codebase more maintainable and improve [Better Code Hub](https://bettercodehub.com)'s **Keep Unit Interfaces Small** guideline rating! 👍 

Here's the gist of this guideline:
- **Definition** 📖 
Limit the number of parameters per unit to at most 4.
- **Why**❓ 
Keeping the number of parameters low makes units easier to understand, test and reuse.
- **How** 🔧 
Reduce the number of parameters by grouping related parameters into objects. Alternatively, try extracting parts of units that require fewer parameters.

You can find more info about this guideline in [Building Maintainable Software](http://shop.oreilly.com/product/0636920049159.do). 📖 
 
---- 
ℹ️ To know how many _other_ refactoring candidates need addressing to get a guideline compliant, select some by clicking on the 🔲  next to them. The risk profile below the candidates signals (✅) when it's enough! 🏁 


----
Good luck and happy coding! :shipit: :sparkles: :100: