### PR TITLE
Refactor ThorpArchive.logEvent(StorageQueueEvent)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,9 +57,8 @@ val zioDependencies = Seq(
   )
 )
 
-// cli -> thorp-lib -> storage-aws -> core -> storage-api -> console -> domain
-//                                            storage-api -> config -> domain
-//                                                           config -> filesystem
+// cli -> thorp-lib -> storage-aws -> core -> storage-api -> console -> config -> domain
+//                                            storage-api ->            config -> filesystem
 
 lazy val thorp = (project in file("."))
   .settings(commonSettings)
@@ -114,7 +113,7 @@ lazy val console = (project in file("console"))
   .settings(commonSettings)
   .settings(zioDependencies)
   .settings(assemblyJarName in assembly := "console.jar")
-  .dependsOn(domain)
+  .dependsOn(config)
 
 lazy val config = (project in file("config"))
   .settings(commonSettings)

--- a/console/src/main/scala/net/kemitix/thorp/console/Console.scala
+++ b/console/src/main/scala/net/kemitix/thorp/console/Console.scala
@@ -61,7 +61,7 @@ object Console {
   final def putMessageLn(line: ConsoleOut): ZIO[Console, Nothing, Unit] =
     ZIO.accessM(_.console putStrLn line)
 
-  final def putMessageLnB(
+  final def putMessageLn(
       line: ConsoleOut.WithBatchMode): ZIO[Console with Config, Nothing, Unit] =
     ZIO.accessM(line() >>= _.console.putStrLn)
 

--- a/console/src/main/scala/net/kemitix/thorp/console/Console.scala
+++ b/console/src/main/scala/net/kemitix/thorp/console/Console.scala
@@ -3,6 +3,7 @@ package net.kemitix.thorp.console
 import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicReference
 
+import net.kemitix.thorp.config.Config
 import zio.{UIO, ZIO}
 
 import scala.{Console => SConsole}
@@ -59,5 +60,9 @@ object Console {
 
   final def putMessageLn(line: ConsoleOut): ZIO[Console, Nothing, Unit] =
     ZIO.accessM(_.console putStrLn line)
+
+  final def putMessageLnB(
+      line: ConsoleOut.WithBatchMode): ZIO[Console with Config, Nothing, Unit] =
+    ZIO.accessM(line() >>= _.console.putStrLn)
 
 }

--- a/console/src/main/scala/net/kemitix/thorp/console/ConsoleOut.scala
+++ b/console/src/main/scala/net/kemitix/thorp/console/ConsoleOut.scala
@@ -1,11 +1,28 @@
 package net.kemitix.thorp.console
 
+import net.kemitix.thorp.config.Config
+import net.kemitix.thorp.domain.StorageQueueEvent.Action
+import net.kemitix.thorp.domain.Terminal._
 import net.kemitix.thorp.domain.{Bucket, RemoteKey, Sources}
+import zio.{UIO, ZIO}
+
+import scala.io.AnsiColor._
 
 sealed trait ConsoleOut {
   def en: String
 }
+
 object ConsoleOut {
+
+  sealed trait WithBatchMode {
+    def en: String
+    def enBatch: String
+    def apply(): ZIO[Config, Nothing, String] =
+      Config.batchMode >>= selectLine
+    private def selectLine(batchMode: Boolean) =
+      if (batchMode) UIO(enBatch) else UIO(en)
+  }
+
   case class ValidConfig(
       bucket: Bucket,
       prefix: RemoteKey,
@@ -17,5 +34,37 @@ object ConsoleOut {
            s"Prefix: ${prefix.key}",
            s"Source: $sourcesList")
         .mkString(", ")
+  }
+
+  case class UploadComplete(remoteKey: RemoteKey)
+      extends ConsoleOut.WithBatchMode {
+    override def en: String =
+      s"${GREEN}Uploaded:$RESET ${remoteKey.key}$eraseToEndOfScreen"
+    override def enBatch: String =
+      s"Uploaded: ${remoteKey.key}"
+  }
+
+  case class CopyComplete(sourceKey: RemoteKey, targetKey: RemoteKey)
+      extends ConsoleOut.WithBatchMode {
+    override def en: String =
+      s"${GREEN}Copied:$RESET ${sourceKey.key} => ${targetKey.key}$eraseToEndOfScreen"
+    override def enBatch: String =
+      s"Copied: ${sourceKey.key} => ${targetKey.key}"
+  }
+
+  case class DeleteComplete(remoteKey: RemoteKey)
+      extends ConsoleOut.WithBatchMode {
+    override def en: String =
+      s"${GREEN}Deleted:$RESET ${remoteKey.key}$eraseToEndOfScreen"
+    override def enBatch: String =
+      s"Deleted: $remoteKey"
+  }
+
+  case class ErrorQueueEventOccurred(action: Action, e: Throwable)
+      extends ConsoleOut.WithBatchMode {
+    override def en: String =
+      s"${action.name} failed: ${action.keys}: ${e.getMessage}"
+    override def enBatch: String =
+      s"${RED}ERROR:$RESET ${action.name} ${action.keys}: ${e.getMessage}$eraseToEndOfScreen"
   }
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
@@ -19,8 +19,7 @@ trait ThorpArchive {
   ): TaskR[Storage with Console with Config, StorageQueueEvent]
 
   def logEvent(
-      event: StorageQueueEvent
-  ): TaskR[Console with Config, StorageQueueEvent] =
+      event: StorageQueueEvent): TaskR[Console with Config, StorageQueueEvent] =
     event match {
       case UploadQueueEvent(remoteKey, _) =>
         ZIO(event) <* logMessage(

--- a/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
@@ -25,13 +25,13 @@ trait ThorpArchive {
       event: StorageQueueEvent): TaskR[Console with Config, StorageQueueEvent] =
     event match {
       case UploadQueueEvent(remoteKey, _) =>
-        ZIO(event) <* Console.putMessageLnB(UploadComplete(remoteKey))
+        ZIO(event) <* Console.putMessageLn(UploadComplete(remoteKey))
       case CopyQueueEvent(sourceKey, targetKey) =>
-        ZIO(event) <* Console.putMessageLnB(CopyComplete(sourceKey, targetKey))
+        ZIO(event) <* Console.putMessageLn(CopyComplete(sourceKey, targetKey))
       case DeleteQueueEvent(remoteKey) =>
-        ZIO(event) <* Console.putMessageLnB(DeleteComplete(remoteKey))
+        ZIO(event) <* Console.putMessageLn(DeleteComplete(remoteKey))
       case ErrorQueueEvent(action, _, e) =>
-        ZIO(event) <* Console.putMessageLnB(ErrorQueueEventOccurred(action, e))
+        ZIO(event) <* Console.putMessageLn(ErrorQueueEventOccurred(action, e))
       case DoNothingQueueEvent(_) => ZIO(event)
       case ShutdownQueueEvent()   => ZIO(event)
     }

--- a/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
@@ -3,17 +3,10 @@ package net.kemitix.thorp.core
 import net.kemitix.thorp.config.Config
 import net.kemitix.thorp.console._
 import net.kemitix.thorp.domain.StorageQueueEvent
-import net.kemitix.thorp.domain.StorageQueueEvent.{
-  CopyQueueEvent,
-  DeleteQueueEvent,
-  DoNothingQueueEvent,
-  ErrorQueueEvent,
-  ShutdownQueueEvent,
-  UploadQueueEvent
-}
+import net.kemitix.thorp.domain.StorageQueueEvent._
 import net.kemitix.thorp.domain.Terminal._
 import net.kemitix.thorp.storage.api.Storage
-import zio.TaskR
+import zio.{TaskR, ZIO}
 
 import scala.io.AnsiColor._
 
@@ -30,43 +23,43 @@ trait ThorpArchive {
   ): TaskR[Console with Config, StorageQueueEvent] =
     event match {
       case UploadQueueEvent(remoteKey, _) =>
-        for {
-          batchMode <- Config.batchMode
-          _ <- TaskR.when(batchMode)(
-            Console.putStrLn(s"Uploaded: ${remoteKey.key}"))
-          _ <- TaskR.when(!batchMode)(
-            Console.putStrLn(
-              s"${GREEN}Uploaded:$RESET ${remoteKey.key}$eraseToEndOfScreen"))
-        } yield event
+        ZIO(event) <* logMessage(
+          s"Uploaded: ${remoteKey.key}",
+          s"${GREEN}Uploaded:$RESET ${remoteKey.key}$eraseToEndOfScreen")
       case CopyQueueEvent(sourceKey, targetKey) =>
-        for {
-          batchMode <- Config.batchMode
-          _ <- TaskR.when(batchMode)(
-            Console.putStrLn(s"Copied: ${sourceKey.key} => ${targetKey.key}"))
-          _ <- TaskR.when(!batchMode)(
-            Console.putStrLn(
-              s"${GREEN}Copied:$RESET ${sourceKey.key} => ${targetKey.key}$eraseToEndOfScreen")
-          )
-        } yield event
+        ZIO(event) <* logMessage(
+          s"Copied: ${sourceKey.key} => ${targetKey.key}",
+          s"${GREEN}Copied:$RESET ${sourceKey.key} => ${targetKey.key}$eraseToEndOfScreen")
       case DeleteQueueEvent(remoteKey) =>
-        for {
-          batchMode <- Config.batchMode
-          _         <- TaskR.when(batchMode)(Console.putStrLn(s"Deleted: $remoteKey"))
-          _ <- TaskR.when(!batchMode)(
-            Console.putStrLn(
-              s"${GREEN}Deleted:$RESET ${remoteKey.key}$eraseToEndOfScreen"))
-        } yield event
+        ZIO(event) <* logMessage(
+          s"Deleted: $remoteKey",
+          s"${GREEN}Deleted:$RESET ${remoteKey.key}$eraseToEndOfScreen")
       case ErrorQueueEvent(action, _, e) =>
-        for {
-          batchMode <- Config.batchMode
-          _ <- TaskR.when(batchMode)(
-            Console.putStrLn(
-              s"${action.name} failed: ${action.keys}: ${e.getMessage}"))
-          _ <- TaskR.when(!batchMode)(Console.putStrLn(
-            s"${RED}ERROR:$RESET ${action.name} ${action.keys}: ${e.getMessage}$eraseToEndOfScreen"))
-        } yield event
+        ZIO(event) <* logMessage(
+          s"${action.name} failed: ${action.keys}: ${e.getMessage}",
+          s"${RED}ERROR:$RESET ${action.name} ${action.keys}: ${e.getMessage}$eraseToEndOfScreen")
       case DoNothingQueueEvent(_) => TaskR(event)
       case ShutdownQueueEvent()   => TaskR(event)
     }
+
+  private def logMessage(
+      batchModeMessage: String,
+      normalMessage: String
+  ): ZIO[Console with Config, Nothing, Unit] = {
+    for {
+      batchMode <- Config.batchMode
+      _ <- alternative(batchMode)(
+        Console.putStrLn(batchModeMessage),
+        Console.putStrLn(normalMessage)
+      )
+    } yield ()
+  }
+
+  private def alternative[R, E, A](b: Boolean)(
+      whenTrue: ZIO[R, E, A],
+      whenFalse: ZIO[R, E, A]
+  ) =
+    if (b) whenTrue.const(())
+    else whenFalse.const(())
 
 }


### PR DESCRIPTION
I've selected [**ThorpArchive.logEvent(StorageQueueEvent)**](https://github.com/kemitix/thorp/blob/adbf8af2f3eb3b61fa342a3f86e991ea4183c546/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala#L28-L70) for refactoring, which is a unit of **40** lines of code. Addressing this will make our codebase more maintainable and improve [Better Code Hub](https://bettercodehub.com)'s **Write Short Units of Code** guideline rating! 👍 

Here's the gist of this guideline:
- **Definition** 📖 
Limit the length of code units to 15 lines of code.
- **Why**❓ 
Small units are easier to analyse, test and reuse.
- **How** 🔧 
When writing new units, don't let them grow above 15 lines of code. When a unit grows beyond this, split it in smaller units of no longer than 15 lines.

You can find more info about this guideline in [Building Maintainable Software](http://shop.oreilly.com/product/0636920049159.do). 📖 
 
---- 
ℹ️ To know how many _other_ refactoring candidates need addressing to get a guideline compliant, select some by clicking on the 🔲  next to them. The risk profile below the candidates signals (✅) when it's enough! 🏁 


----
Good luck and happy coding! :shipit: :sparkles: :100: