### PR TITLE
Refactor Program.updateArchive(ThorpArchive,Action,Int,Stream,Long)

### DIFF
--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -62,23 +62,13 @@ trait Program {
       acc: (Stream[StorageQueueEvent], Long),
       indexedAction: (Action, Int)
   ) = {
-    val (action, index)     = indexedAction
-    val (stream, bytesToDo) = acc
-    val remainingBytes      = bytesToDo - action.size
-    updateArchive(archive, action, index, stream, remainingBytes)
-      .map((_, remainingBytes))
+    val (action, index)           = indexedAction
+    val (queuedEvents, bytesToDo) = acc
+    val remainingBytes            = bytesToDo - action.size
+    archive
+      .update(index, action, remainingBytes)
+      .map(events => (queuedEvents ++ Stream(events), remainingBytes))
   }
-
-  private def updateArchive(
-      archive: ThorpArchive,
-      action: Action,
-      index: Int,
-      stream: Stream[StorageQueueEvent],
-      remainingBytes: Long
-  ) =
-    for {
-      event <- archive.update(index, action, remainingBytes)
-    } yield stream ++ Stream(event)
 
 }
 

--- a/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
+++ b/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala
@@ -4,7 +4,6 @@ import net.kemitix.thorp.config._
 import net.kemitix.thorp.console._
 import net.kemitix.thorp.core.CoreTypes.CoreProgram
 import net.kemitix.thorp.core._
-import net.kemitix.thorp.domain.StorageQueueEvent
 import zio.ZIO
 
 trait Program {
@@ -24,50 +23,42 @@ trait Program {
   private def showVersion: ConfigOptions => Boolean =
     cli => ConfigQuery.showVersion(cli)
 
-  private def execute = {
+  private def execute =
     for {
       plan    <- PlanBuilder.createPlan
       archive <- UnversionedMirrorArchive.default(plan.syncTotals)
       events  <- applyPlan(archive, plan)
       _       <- SyncLogging.logRunFinished(events)
     } yield ()
-  }
 
   private def handleErrors(throwable: Throwable) =
-    for {
-      _ <- Console.putStrLn("There were errors:")
-      _ <- throwable match {
-        case ConfigValidationException(errors) =>
-          ZIO.foreach_(errors)(error => Console.putStrLn(s"- $error"))
-      }
-    } yield ()
+    Console.putStrLn("There were errors:") *> logValidationErrors(throwable)
 
-  private def applyPlan(
-      archive: ThorpArchive,
-      syncPlan: SyncPlan
-  ) = {
-    val zero: (Stream[StorageQueueEvent], Long) =
-      (Stream(), syncPlan.syncTotals.totalSizeBytes)
-    val actions = syncPlan.actions.zipWithIndex
+  private def logValidationErrors(throwable: Throwable) =
+    throwable match {
+      case ConfigValidationException(errors) =>
+        ZIO.foreach_(errors)(error => Console.putStrLn(s"- $error"))
+    }
+
+  private def applyPlan(archive: ThorpArchive, syncPlan: SyncPlan) =
     ZIO
-      .foldLeft(actions)(zero)((acc, action) =>
-        applyAction(archive, acc, action))
-      .map {
-        case (events, _) => events
-      }
-  }
+      .foldLeft(sequenceActions(syncPlan.actions))(
+        EventQueue(Stream.empty, syncPlan.syncTotals.totalSizeBytes))(
+        applyAction(archive)(_, _))
+      .map(_.events)
 
-  private def applyAction(
-      archive: ThorpArchive,
-      acc: (Stream[StorageQueueEvent], Long),
-      indexedAction: (Action, Int)
+  private def sequenceActions(actions: Stream[Action]) =
+    actions.zipWithIndex
+      .map({ case (a, i) => SequencedAction(a, i) })
+
+  private def applyAction(archive: ThorpArchive)(
+      queue: EventQueue,
+      action: SequencedAction
   ) = {
-    val (action, index)           = indexedAction
-    val (queuedEvents, bytesToDo) = acc
-    val remainingBytes            = bytesToDo - action.size
+    val remainingBytes = queue.bytesInQueue - action.action.size
     archive
-      .update(index, action, remainingBytes)
-      .map(events => (queuedEvents ++ Stream(events), remainingBytes))
+      .update(action, remainingBytes)
+      .map(events => EventQueue(queue.events ++ Stream(events), remainingBytes))
   }
 
 }

--- a/core/src/main/scala/net/kemitix/thorp/core/EventQueue.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/EventQueue.scala
@@ -1,0 +1,8 @@
+package net.kemitix.thorp.core
+
+import net.kemitix.thorp.domain.StorageQueueEvent
+
+case class EventQueue(
+    events: Stream[StorageQueueEvent],
+    bytesInQueue: Long
+)

--- a/core/src/main/scala/net/kemitix/thorp/core/SequencedAction.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/SequencedAction.scala
@@ -1,0 +1,6 @@
+package net.kemitix.thorp.core
+
+case class SequencedAction(
+    action: Action,
+    index: Int
+)

--- a/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ThorpArchive.scala
@@ -16,8 +16,7 @@ import zio.{TaskR, ZIO}
 trait ThorpArchive {
 
   def update(
-      index: Int,
-      action: Action,
+      sequencedAction: SequencedAction,
       totalBytesSoFar: Long
   ): TaskR[Storage with Console with Config, StorageQueueEvent]
 


### PR DESCRIPTION
I've selected [**Program.updateArchive(ThorpArchive,Action,Int,Stream,Long)**](https://github.com/kemitix/thorp/blob/e3b0260b6dd035da4c0bcdf8baaac51914be34bb/cli/src/main/scala/net/kemitix/thorp/cli/Program.scala#L72-L81) for refactoring, which is a unit of **3** lines of code and **5** parameters. Addressing this will make our codebase more maintainable and improve [Better Code Hub](https://bettercodehub.com)'s **Keep Unit Interfaces Small** guideline rating! 👍 

Here's the gist of this guideline:
- **Definition** 📖 
Limit the number of parameters per unit to at most 4.
- **Why**❓ 
Keeping the number of parameters low makes units easier to understand, test and reuse.
- **How** 🔧 
Reduce the number of parameters by grouping related parameters into objects. Alternatively, try extracting parts of units that require fewer parameters.

You can find more info about this guideline in [Building Maintainable Software](http://shop.oreilly.com/product/0636920049159.do). 📖 
 
---- 
ℹ️ To know how many _other_ refactoring candidates need addressing to get a guideline compliant, select some by clicking on the 🔲  next to them. The risk profile below the candidates signals (✅) when it's enough! 🏁 


----
Good luck and happy coding! :shipit: :sparkles: :100: