### PR TITLE
Refactor ActionGenerator.genAction(S3MetaData,Stream,Bucket)

### DIFF
--- a/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
@@ -8,17 +8,17 @@ import zio.RIO
 object ActionGenerator {
 
   def createActions(
-      s3MetaData: MatchedMetadata,
+      matchedMetadata: MatchedMetadata,
       previousActions: Stream[Action]
   ): RIO[Config, Stream[Action]] =
     for {
       bucket <- Config.bucket
-    } yield genAction(s3MetaData, previousActions, bucket)
+    } yield genAction(matchedMetadata, previousActions, bucket)
 
-  private def genAction(s3MetaData: MatchedMetadata,
+  private def genAction(matchedMetadata: MatchedMetadata,
                         previousActions: Stream[Action],
                         bucket: Bucket): Stream[Action] = {
-    s3MetaData match {
+    matchedMetadata match {
       // #1 local exists, remote exists, remote matches - do nothing
       case MatchedMetadata(localFile, _, Some(RemoteMetaData(key, hash, _)))
           if LocalFile.matchesHash(localFile)(hash) =>

--- a/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
@@ -3,7 +3,7 @@ package net.kemitix.thorp.core
 import net.kemitix.thorp.config.Config
 import net.kemitix.thorp.core.Action.{DoNothing, ToCopy, ToUpload}
 import net.kemitix.thorp.domain._
-import zio.{RIO, ZIO}
+import zio.RIO
 
 object ActionGenerator {
 

--- a/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala
@@ -20,9 +20,8 @@ object ActionGenerator {
       matchedMetadata: MatchedMetadata,
       previousActions: Stream[Action]): TaggedMetadata = {
     val remoteExists = matchedMetadata.matchByKey.nonEmpty
-    val remoteMatches = matchedMetadata.matchByKey.nonEmpty &&
-      LocalFile.matchesHash(matchedMetadata.localFile)(
-        matchedMetadata.matchByKey.head.hash)
+    val remoteMatches = remoteExists && matchedMetadata.matchByKey.exists(m =>
+      LocalFile.matchesHash(matchedMetadata.localFile)(m.hash))
     val anyMatches = matchedMetadata.matchByHash.nonEmpty
     TaggedMetadata(matchedMetadata,
                    previousActions,

--- a/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/PlanBuilder.scala
@@ -57,14 +57,14 @@ object PlanBuilder {
       localFiles: Stream[LocalFile]
   ) =
     ZIO.foldLeft(localFiles)(Stream.empty[Action])((acc, localFile) =>
-      createActionFromLocalFile(remoteObjects, acc, localFile).map(_ ++ acc))
+      createActionFromLocalFile(remoteObjects, acc, localFile).map(_ #:: acc))
 
   private def createActionFromLocalFile(
       remoteObjects: RemoteObjects,
       previousActions: Stream[Action],
       localFile: LocalFile
   ) =
-    ActionGenerator.createActions(
+    ActionGenerator.createAction(
       S3MetaDataEnricher.getMetadata(localFile, remoteObjects),
       previousActions)
 

--- a/core/src/main/scala/net/kemitix/thorp/core/S3MetaDataEnricher.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/S3MetaDataEnricher.scala
@@ -7,9 +7,9 @@ object S3MetaDataEnricher {
   def getMetadata(
       localFile: LocalFile,
       s3ObjectsData: S3ObjectsData
-  ): S3MetaData = {
+  ): MatchedMetadata = {
     val (keyMatches, hashMatches) = getS3Status(localFile, s3ObjectsData)
-    S3MetaData(
+    MatchedMetadata(
       localFile,
       matchByKey = keyMatches.map { hm =>
         RemoteMetaData(localFile.remoteKey, hm.hash, hm.modified)

--- a/core/src/main/scala/net/kemitix/thorp/core/S3MetaDataEnricher.scala
+++ b/core/src/main/scala/net/kemitix/thorp/core/S3MetaDataEnricher.scala
@@ -6,9 +6,9 @@ object S3MetaDataEnricher {
 
   def getMetadata(
       localFile: LocalFile,
-      s3ObjectsData: S3ObjectsData
+      remoteObjects: RemoteObjects
   ): MatchedMetadata = {
-    val (keyMatches, hashMatches) = getS3Status(localFile, s3ObjectsData)
+    val (keyMatches, hashMatches) = getS3Status(localFile, remoteObjects)
     MatchedMetadata(
       localFile,
       matchByKey = keyMatches.map { hm =>
@@ -22,13 +22,13 @@ object S3MetaDataEnricher {
 
   def getS3Status(
       localFile: LocalFile,
-      s3ObjectsData: S3ObjectsData
+      remoteObjects: RemoteObjects
   ): (Option[HashModified], Set[(MD5Hash, KeyModified)]) = {
-    val matchingByKey = s3ObjectsData.byKey.get(localFile.remoteKey)
+    val matchingByKey = remoteObjects.byKey.get(localFile.remoteKey)
     val matchingByHash = localFile.hashes
       .map {
         case (_, md5Hash) =>
-          s3ObjectsData.byHash
+          remoteObjects.byHash
             .getOrElse(md5Hash, Set())
             .map(km => (md5Hash, km))
       }

--- a/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
@@ -206,7 +206,7 @@ class ActionGeneratorSuite extends FunSpec {
       for {
         config  <- ConfigurationBuilder.buildConfig(configOptions)
         _       <- Config.set(config)
-        actions <- ActionGenerator.createActions(input, previousActions)
+        actions <- ActionGenerator.createAction(input, previousActions)
       } yield actions
 
     new DefaultRuntime {}.unsafeRunSync {

--- a/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/ActionGeneratorSuite.scala
@@ -41,7 +41,7 @@ class ActionGeneratorSuite extends FunSpec {
         theRemoteMetadata = RemoteMetaData(theFile.remoteKey,
                                            theHash,
                                            lastModified)
-        input = S3MetaData(
+        input = MatchedMetadata(
           theFile, // local exists
           matchByHash = Set(theRemoteMetadata), // remote matches
           matchByKey = Some(theRemoteMetadata) // remote exists
@@ -72,7 +72,7 @@ class ActionGeneratorSuite extends FunSpec {
         otherRemoteMetadata = RemoteMetaData(otherRemoteKey,
                                              theHash,
                                              lastModified)
-        input = S3MetaData(
+        input = MatchedMetadata(
           theFile, // local exists
           matchByHash = Set(otherRemoteMetadata), // other matches
           matchByKey = None) // remote is missing
@@ -100,9 +100,9 @@ class ActionGeneratorSuite extends FunSpec {
                                                 sourcePath,
                                                 sources,
                                                 prefix)
-          input = S3MetaData(theFile, // local exists
-                             matchByHash = Set.empty, // other no matches
-                             matchByKey = None) // remote is missing
+          input = MatchedMetadata(theFile, // local exists
+                                  matchByHash = Set.empty, // other no matches
+                                  matchByKey = None) // remote is missing
         } yield (theFile, input)
         it("upload") {
           env.map({
@@ -134,7 +134,7 @@ class ActionGeneratorSuite extends FunSpec {
         oldRemoteMetadata = RemoteMetaData(theRemoteKey,
                                            hash = oldHash, // remote no match
                                            lastModified = lastModified)
-        input = S3MetaData(
+        input = MatchedMetadata(
           theFile, // local exists
           matchByHash = Set(otherRemoteMetadata), // other matches
           matchByKey = Some(oldRemoteMetadata)) // remote exists
@@ -167,7 +167,7 @@ class ActionGeneratorSuite extends FunSpec {
         theRemoteKey      = theFile.remoteKey
         oldHash           = MD5Hash("old-hash")
         theRemoteMetadata = RemoteMetaData(theRemoteKey, oldHash, lastModified)
-        input = S3MetaData(
+        input = MatchedMetadata(
           theFile, // local exists
           matchByHash = Set.empty, // remote no match, other no match
           matchByKey = Some(theRemoteMetadata) // remote exists
@@ -196,7 +196,7 @@ class ActionGeneratorSuite extends FunSpec {
   }
 
   private def invoke(
-      input: S3MetaData,
+      input: MatchedMetadata,
       previousActions: Stream[Action]
   ) = {
     type TestEnv = Config with FileSystem

--- a/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/DummyStorageService.scala
@@ -7,7 +7,7 @@ import net.kemitix.thorp.domain._
 import net.kemitix.thorp.storage.api.Storage
 import zio.{RIO, UIO}
 
-case class DummyStorageService(s3ObjectData: S3ObjectsData,
+case class DummyStorageService(remoteObjects: RemoteObjects,
                                uploadFiles: Map[File, (RemoteKey, MD5Hash)])
     extends Storage.Service {
 
@@ -17,8 +17,8 @@ case class DummyStorageService(s3ObjectData: S3ObjectsData,
   override def listObjects(
       bucket: Bucket,
       prefix: RemoteKey
-  ): RIO[Console, S3ObjectsData] =
-    RIO(s3ObjectData)
+  ): RIO[Console, RemoteObjects] =
+    RIO(remoteObjects)
 
   override def upload(
       localFile: LocalFile,

--- a/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/LocalFileStreamSuite.scala
@@ -56,7 +56,7 @@ class LocalFileStreamSuite extends FunSpec {
       with Hasher.Test
     val testEnv: TestEnv = new Storage.Test with Console.Test with Config.Live
     with FileSystem.Live with Hasher.Test {
-      override def listResult: Task[S3ObjectsData] =
+      override def listResult: Task[RemoteObjects] =
         Task.die(new NotImplementedError)
       override def uploadResult: UIO[StorageQueueEvent] =
         Task.die(new NotImplementedError)

--- a/core/src/test/scala/net/kemitix/thorp/core/MatchedMetadataEnricherSuite.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/MatchedMetadataEnricherSuite.scala
@@ -8,7 +8,7 @@ import net.kemitix.thorp.domain.HashType.MD5
 import net.kemitix.thorp.domain._
 import org.scalatest.FunSpec
 
-class S3MetaDataEnricherSuite extends FunSpec {
+class MatchedMetadataEnricherSuite extends FunSpec {
   val lastModified       = LastModified(Instant.now())
   private val source     = Resource(this, "upload")
   private val sourcePath = source.toPath
@@ -50,9 +50,9 @@ class S3MetaDataEnricherSuite extends FunSpec {
       it("generates valid metadata") {
         env.map({
           case (theFile, theRemoteMetadata, s3) => {
-            val expected = S3MetaData(theFile,
-                                      matchByHash = Set(theRemoteMetadata),
-                                      matchByKey = Some(theRemoteMetadata))
+            val expected = MatchedMetadata(theFile,
+                                           matchByHash = Set(theRemoteMetadata),
+                                           matchByKey = Some(theRemoteMetadata))
             val result = getMetadata(theFile, s3)
             assertResult(expected)(result)
           }
@@ -78,9 +78,9 @@ class S3MetaDataEnricherSuite extends FunSpec {
       it("generates valid metadata") {
         env.map({
           case (theFile, theRemoteMetadata, s3) => {
-            val expected = S3MetaData(theFile,
-                                      matchByHash = Set(theRemoteMetadata),
-                                      matchByKey = Some(theRemoteMetadata))
+            val expected = MatchedMetadata(theFile,
+                                           matchByHash = Set(theRemoteMetadata),
+                                           matchByKey = Some(theRemoteMetadata))
             val result = getMetadata(theFile, s3)
             assertResult(expected)(result)
           }
@@ -109,9 +109,10 @@ class S3MetaDataEnricherSuite extends FunSpec {
       it("generates valid metadata") {
         env.map({
           case (theFile, otherRemoteMetadata, s3) => {
-            val expected = S3MetaData(theFile,
-                                      matchByHash = Set(otherRemoteMetadata),
-                                      matchByKey = None)
+            val expected = MatchedMetadata(theFile,
+                                           matchByHash =
+                                             Set(otherRemoteMetadata),
+                                           matchByKey = None)
             val result = getMetadata(theFile, s3)
             assertResult(expected)(result)
           }
@@ -133,7 +134,9 @@ class S3MetaDataEnricherSuite extends FunSpec {
         env.map({
           case (theFile, s3) => {
             val expected =
-              S3MetaData(theFile, matchByHash = Set.empty, matchByKey = None)
+              MatchedMetadata(theFile,
+                              matchByHash = Set.empty,
+                              matchByKey = None)
             val result = getMetadata(theFile, s3)
             assertResult(expected)(result)
           }
@@ -169,9 +172,10 @@ class S3MetaDataEnricherSuite extends FunSpec {
       it("generates valid metadata") {
         env.map({
           case (theFile, theRemoteMetadata, otherRemoteMetadata, s3) => {
-            val expected = S3MetaData(theFile,
-                                      matchByHash = Set(otherRemoteMetadata),
-                                      matchByKey = Some(theRemoteMetadata))
+            val expected = MatchedMetadata(theFile,
+                                           matchByHash =
+                                             Set(otherRemoteMetadata),
+                                           matchByKey = Some(theRemoteMetadata))
             val result = getMetadata(theFile, s3)
             assertResult(expected)(result)
           }
@@ -201,9 +205,9 @@ class S3MetaDataEnricherSuite extends FunSpec {
       it("generates valid metadata") {
         env.map({
           case (theFile, theRemoteMetadata, s3) => {
-            val expected = S3MetaData(theFile,
-                                      matchByHash = Set.empty,
-                                      matchByKey = Some(theRemoteMetadata))
+            val expected = MatchedMetadata(theFile,
+                                           matchByHash = Set.empty,
+                                           matchByKey = Some(theRemoteMetadata))
             val result = getMetadata(theFile, s3)
             assertResult(expected)(result)
           }

--- a/domain/src/main/scala/net/kemitix/thorp/domain/MatchedMetadata.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/MatchedMetadata.scala
@@ -1,7 +1,7 @@
 package net.kemitix.thorp.domain
 
 // For the LocalFile, the set of matching S3 objects with the same MD5Hash, and any S3 object with the same remote key
-final case class S3MetaData(
+final case class MatchedMetadata(
     localFile: LocalFile,
     matchByHash: Set[RemoteMetaData],
     matchByKey: Option[RemoteMetaData]

--- a/domain/src/main/scala/net/kemitix/thorp/domain/RemoteObjects.scala
+++ b/domain/src/main/scala/net/kemitix/thorp/domain/RemoteObjects.scala
@@ -3,7 +3,7 @@ package net.kemitix.thorp.domain
 /**
   * A list of objects and their MD5 hash values.
   */
-final case class S3ObjectsData(
+final case class RemoteObjects(
     byHash: Map[MD5Hash, Set[KeyModified]] = Map.empty,
     byKey: Map[RemoteKey, HashModified] = Map.empty
 )

--- a/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
+++ b/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
@@ -15,7 +15,7 @@ object Storage {
     def listObjects(
         bucket: Bucket,
         prefix: RemoteKey
-    ): RIO[Storage with Console, S3ObjectsData]
+    ): RIO[Storage with Console, RemoteObjects]
 
     def upload(
         localFile: LocalFile,
@@ -40,7 +40,7 @@ object Storage {
 
   trait Test extends Storage {
 
-    def listResult: Task[S3ObjectsData]
+    def listResult: Task[RemoteObjects]
     def uploadResult: UIO[StorageQueueEvent]
     def copyResult: UIO[StorageQueueEvent]
     def deleteResult: UIO[StorageQueueEvent]
@@ -50,7 +50,7 @@ object Storage {
 
       override def listObjects(
           bucket: Bucket,
-          prefix: RemoteKey): RIO[Storage with Console, S3ObjectsData] =
+          prefix: RemoteKey): RIO[Storage with Console, RemoteObjects] =
         listResult
 
       override def upload(
@@ -78,7 +78,7 @@ object Storage {
   }
 
   object Test extends Test {
-    override def listResult: Task[S3ObjectsData] =
+    override def listResult: Task[RemoteObjects] =
       Task.die(new NotImplementedError)
     override def uploadResult: UIO[StorageQueueEvent] =
       Task.die(new NotImplementedError)
@@ -91,7 +91,7 @@ object Storage {
   }
 
   final def list(bucket: Bucket,
-                 prefix: RemoteKey): RIO[Storage with Console, S3ObjectsData] =
+                 prefix: RemoteKey): RIO[Storage with Console, RemoteObjects] =
     ZIO.accessM(_.storage listObjects (bucket, prefix))
 
   final def upload(

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Lister.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/Lister.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.model.{
   S3ObjectSummary
 }
 import net.kemitix.thorp.console._
-import net.kemitix.thorp.domain.{Bucket, RemoteKey, S3ObjectsData}
+import net.kemitix.thorp.domain.{Bucket, RemoteKey, RemoteObjects}
 import net.kemitix.thorp.storage.aws.S3ObjectsByHash.byHash
 import net.kemitix.thorp.storage.aws.S3ObjectsByKey.byKey
 import zio.{Task, RIO}
@@ -21,7 +21,7 @@ trait Lister {
   def listObjects(amazonS3: AmazonS3.Client)(
       bucket: Bucket,
       prefix: RemoteKey
-  ): RIO[Console, S3ObjectsData] = {
+  ): RIO[Console, RemoteObjects] = {
 
     def request =
       new ListObjectsV2Request()
@@ -48,7 +48,7 @@ trait Lister {
 
     fetch(request)
       .map(summaries => {
-        S3ObjectsData(byHash(summaries), byKey(summaries))
+        RemoteObjects(byHash(summaries), byKey(summaries))
       })
   }
 

--- a/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
+++ b/storage-aws/src/main/scala/net/kemitix/thorp/storage/aws/S3Storage.scala
@@ -20,7 +20,7 @@ object S3Storage {
         AmazonTransferManager(TransferManagerBuilder.defaultTransferManager)
 
       override def listObjects(bucket: Bucket,
-                               prefix: RemoteKey): RIO[Console, S3ObjectsData] =
+                               prefix: RemoteKey): RIO[Console, RemoteObjects] =
         Lister.listObjects(client)(bucket, prefix)
 
       override def upload(

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/AmazonS3ClientTestFixture.scala
@@ -26,7 +26,7 @@ trait AmazonS3ClientTestFixture extends MockFactory {
         override def listObjects(
             bucket: Bucket,
             prefix: RemoteKey
-        ): RIO[Console, S3ObjectsData] =
+        ): RIO[Console, RemoteObjects] =
           Lister.listObjects(client)(bucket, prefix)
 
         override def upload(

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/ListerTest.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/ListerTest.scala
@@ -34,7 +34,7 @@ class ListerTest extends FreeSpec {
           RemoteKey(key) -> HashModified(MD5Hash(etag),
                                          LastModified(nowInstant))
         )
-        val expected = Right(S3ObjectsData(expectedHashMap, expectedKeyMap))
+        val expected = Right(RemoteObjects(expectedHashMap, expectedKeyMap))
         new AmazonS3ClientTestFixture {
           (fixture.amazonS3Client.listObjectsV2 _)
             .when()
@@ -65,7 +65,7 @@ class ListerTest extends FreeSpec {
           RemoteKey(key2) -> HashModified(MD5Hash(etag2),
                                           LastModified(nowInstant))
         )
-        val expected = Right(S3ObjectsData(expectedHashMap, expectedKeyMap))
+        val expected = Right(RemoteObjects(expectedHashMap, expectedKeyMap))
         new AmazonS3ClientTestFixture {
           (fixture.amazonS3Client.listObjectsV2 _)
             .when()

--- a/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
+++ b/storage-aws/src/test/scala/net/kemitix/thorp/storage/aws/StorageServiceSuite.scala
@@ -38,7 +38,7 @@ class StorageServiceSuite extends FunSpec with MockFactory {
                                                 sources,
                                                 prefix)
       lastModified = LastModified(Instant.now)
-      s3ObjectsData = S3ObjectsData(
+      s3ObjectsData = RemoteObjects(
         byHash = Map(
           hash -> Set(KeyModified(key, lastModified),
                       KeyModified(keyOtherKey.remoteKey, lastModified)),
@@ -59,7 +59,7 @@ class StorageServiceSuite extends FunSpec with MockFactory {
        diffHash,
        key)
 
-    def invoke(localFile: LocalFile, s3ObjectsData: S3ObjectsData) =
+    def invoke(localFile: LocalFile, s3ObjectsData: RemoteObjects) =
       S3MetaDataEnricher.getS3Status(localFile, s3ObjectsData)
 
     def getMatchesByKey(


### PR DESCRIPTION
I've selected [**ActionGenerator.genAction(S3MetaData,Stream,Bucket)**](https://github.com/kemitix/thorp/blob/e3b0260b6dd035da4c0bcdf8baaac51914be34bb/core/src/main/scala/net/kemitix/thorp/core/ActionGenerator.scala#L18-L46) for refactoring, which is a unit of **21** lines of code and **3** parameters. Addressing this will make our codebase more maintainable and improve [Better Code Hub](https://bettercodehub.com)'s **Keep Unit Interfaces Small** guideline rating! 👍 

Here's the gist of this guideline:
- **Definition** 📖 
Limit the number of parameters per unit to at most 4.
- **Why**❓ 
Keeping the number of parameters low makes units easier to understand, test and reuse.
- **How** 🔧 
Reduce the number of parameters by grouping related parameters into objects. Alternatively, try extracting parts of units that require fewer parameters.

You can find more info about this guideline in [Building Maintainable Software](http://shop.oreilly.com/product/0636920049159.do). 📖 
 
---- 
ℹ️ To know how many _other_ refactoring candidates need addressing to get a guideline compliant, select some by clicking on the 🔲  next to them. The risk profile below the candidates signals (✅) when it's enough! 🏁 


----
Good luck and happy coding! :shipit: :sparkles: :100: