### PR TITLE
java.lang.StackOverflowError

### DIFF
--- a/core/src/test/scala/net/kemitix/thorp/core/PlanExecutorTest.scala
+++ b/core/src/test/scala/net/kemitix/thorp/core/PlanExecutorTest.scala
@@ -1,0 +1,55 @@
+package net.kemitix.thorp.core
+
+import net.kemitix.thorp.config.Config
+import net.kemitix.thorp.console.Console
+import net.kemitix.thorp.core.Action.DoNothing
+import net.kemitix.thorp.domain.{
+  Bucket,
+  RemoteKey,
+  StorageQueueEvent,
+  SyncTotals
+}
+import net.kemitix.thorp.storage.api.Storage
+import org.scalatest.FreeSpec
+import zio.{DefaultRuntime, ZIO}
+
+class PlanExecutorTest extends FreeSpec {
+
+  private def subject(in: Stream[Int]): ZIO[Any, Throwable, Stream[Int]] =
+    ZIO.foldLeft(in)(Stream.empty[Int])((s, i) => ZIO(i #:: s)).map(_.reverse)
+
+  "zio foreach on a stream can be a stream" in {
+    val input   = (1 to 1000000).toStream
+    val program = subject(input)
+    val result  = new DefaultRuntime {}.unsafeRunSync(program).toEither
+    assertResult(Right(input))(result)
+  }
+
+  "build plan with 100,000 actions" in {
+    val nActions  = 100000
+    val bucket    = Bucket("bucket")
+    val remoteKey = RemoteKey("remoteKey")
+    val input     = (1 to nActions).toStream.map(DoNothing(bucket, remoteKey, _))
+
+    val syncTotals  = SyncTotals.empty
+    val archiveTask = UnversionedMirrorArchive.default(syncTotals)
+
+    val syncPlan = SyncPlan(input, syncTotals)
+    val program: ZIO[Storage with Config with Console,
+                     Throwable,
+                     Seq[StorageQueueEvent]] =
+      archiveTask.flatMap(archive =>
+        PlanExecutor.executePlan(archive, syncPlan))
+
+    val result: Either[Throwable, Seq[StorageQueueEvent]] =
+      new DefaultRuntime {}.unsafeRunSync(program.provide(TestEnv)).toEither
+
+    val expected = Right(
+      (1 to nActions).toStream
+        .map(_ => StorageQueueEvent.DoNothingQueueEvent(remoteKey)))
+    assertResult(expected)(result)
+  }
+
+  object TestEnv extends Storage.Test with Config.Live with Console.Test
+
+}

--- a/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
+++ b/storage-api/src/main/scala/net/kemitix/thorp/storage/api/Storage.scala
@@ -40,11 +40,16 @@ object Storage {
 
   trait Test extends Storage {
 
-    def listResult: Task[RemoteObjects]
-    def uploadResult: UIO[StorageQueueEvent]
-    def copyResult: UIO[StorageQueueEvent]
-    def deleteResult: UIO[StorageQueueEvent]
-    def shutdownResult: UIO[StorageQueueEvent]
+    def listResult: Task[RemoteObjects] =
+      Task.die(new NotImplementedError)
+    def uploadResult: UIO[StorageQueueEvent] =
+      Task.die(new NotImplementedError)
+    def copyResult: UIO[StorageQueueEvent] =
+      Task.die(new NotImplementedError)
+    def deleteResult: UIO[StorageQueueEvent] =
+      Task.die(new NotImplementedError)
+    def shutdownResult: UIO[StorageQueueEvent] =
+      Task.die(new NotImplementedError)
 
     val storage: Service = new Service {
 
@@ -77,18 +82,7 @@ object Storage {
     }
   }
 
-  object Test extends Test {
-    override def listResult: Task[RemoteObjects] =
-      Task.die(new NotImplementedError)
-    override def uploadResult: UIO[StorageQueueEvent] =
-      Task.die(new NotImplementedError)
-    override def copyResult: UIO[StorageQueueEvent] =
-      Task.die(new NotImplementedError)
-    override def deleteResult: UIO[StorageQueueEvent] =
-      Task.die(new NotImplementedError)
-    override def shutdownResult: UIO[StorageQueueEvent] =
-      Task.die(new NotImplementedError)
-  }
+  object Test extends Test
 
   final def list(bucket: Bucket,
                  prefix: RemoteKey): RIO[Storage with Console, RemoteObjects] =


### PR DESCRIPTION
```
Found 33894 remote objects
Found 24841 files
java.lang.StackOverflowError
	at scala.collection.mutable.AbstractBuffer.<init>(Buffer.scala:50)
	at scala.collection.mutable.ListBuffer.<init>(ListBuffer.scala:48)
	at scala.collection.mutable.LazyBuilder.<init>(LazyBuilder.scala:29)
	at scala.collection.immutable.Stream$StreamBuilder.<init>(Stream.scala:1100)
	at scala.collection.immutable.Stream$.newBuilder(Stream.scala:1093)
	at scala.collection.generic.GenericTraversableTemplate.genericBuilder(GenericTraversableTemplate.scala:72)
	at scala.collection.generic.GenericTraversableTemplate.genericBuilder$(GenericTraversableTemplate.scala:72)
	at scala.collection.AbstractTraversable.genericBuilder(Traversable.scala:108)
	at scala.collection.generic.GenTraversableFactory$GenericCanBuildFrom.apply(GenTraversableFactory.scala:59)
	at scala.collection.generic.GenTraversableFactory$GenericCanBuildFrom.apply(GenTraversableFactory.scala:54)
	at scala.collection.immutable.Stream.flatMap(Stream.scala:322)
	at scala.collection.immutable.Stream.$anonfun$flatMap$1(Stream.scala:497)
	at scala.collection.immutable.Stream.$anonfun$append$1(Stream.scala:255)
	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1171)
	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1161)
	at scala.collection.LinearSeqOptimized.foldRight(LinearSeqOptimized.scala:135)
	at scala.collection.LinearSeqOptimized.foldRight$(LinearSeqOptimized.scala:133)
	at scala.collection.immutable.Stream.foldRight(Stream.scala:204)
	at scala.collection.LinearSeqOptimized.foldRight(LinearSeqOptimized.scala:135)
	at scala.collection.LinearSeqOptimized.foldRight$(LinearSeqOptimized.scala:133)
	at scala.collection.immutable.Stream.foldRight(Stream.scala:204)
...
```