### PR TITLE
Progress UI should be updated when upload fails

### DIFF
--- a/uishell/src/main/scala/net/kemitix/thorp/uishell/ProgressUI.scala
+++ b/uishell/src/main/scala/net/kemitix/thorp/uishell/ProgressUI.scala
@@ -20,10 +20,11 @@ object ProgressUI {
 
   private val statusHeight = 3
 
-  def handle(localFile: LocalFile,
-             bytesTransferred: Long,
-             index: Int,
-             totalBytesSoFar: Long): ZIO[Console with Config, Nothing, Unit] =
+  def requestCycle(
+      localFile: LocalFile,
+      bytesTransferred: Long,
+      index: Int,
+      totalBytesSoFar: Long): ZIO[Console with Config, Nothing, Unit] =
     for {
       _ <- ZIO.when(bytesTransferred < localFile.file.length())(
         stillUploading(localFile.remoteKey,

--- a/uishell/src/main/scala/net/kemitix/thorp/uishell/ProgressUI.scala
+++ b/uishell/src/main/scala/net/kemitix/thorp/uishell/ProgressUI.scala
@@ -63,7 +63,7 @@ object ProgressUI {
     } *> Console.putStr(resetCursor)
   }
 
-  private def finishedUploading(
+  def finishedUploading(
       remoteKey: RemoteKey
   ): ZIO[Any, Nothing, Unit] = {
     UIO(uploads.updateAndGet((m: Map[RemoteKey, UploadState]) =>

--- a/uishell/src/main/scala/net/kemitix/thorp/uishell/ProgressUI.scala
+++ b/uishell/src/main/scala/net/kemitix/thorp/uishell/ProgressUI.scala
@@ -11,7 +11,7 @@ import zio.{UIO, ZIO}
 
 import scala.io.AnsiColor.{GREEN, RESET}
 
-object UIRequestCycle {
+object ProgressUI {
 
   private case class UploadState(transferred: Long, fileLength: Long)
 

--- a/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
+++ b/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
@@ -35,10 +35,7 @@ object UIShell {
                                   bytesTransferred,
                                   index,
                                   totalBytesSoFar) =>
-          UIRequestCycle.handle(localFile,
-                                bytesTransferred,
-                                index,
-                                totalBytesSoFar)
+          ProgressUI.handle(localFile, bytesTransferred, index, totalBytesSoFar)
       }
     }
 

--- a/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
+++ b/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
@@ -51,7 +51,8 @@ object UIShell {
         case StorageEvent.CopyEvent(sourceKey, targetKey) =>
           Console.putMessageLnB(CopyComplete(sourceKey, targetKey), batchMode)
         case StorageEvent.UploadEvent(remoteKey, md5Hash) =>
-          Console.putMessageLnB(UploadComplete(remoteKey), batchMode)
+          ProgressUI.finishedUploading(remoteKey) *>
+            Console.putMessageLnB(UploadComplete(remoteKey), batchMode)
         case StorageEvent.DeleteEvent(remoteKey) =>
           Console.putMessageLnB(DeleteComplete(remoteKey), batchMode)
         case StorageEvent.ErrorEvent(action, remoteKey, e) =>

--- a/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
+++ b/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
@@ -35,7 +35,10 @@ object UIShell {
                                   bytesTransferred,
                                   index,
                                   totalBytesSoFar) =>
-          ProgressUI.handle(localFile, bytesTransferred, index, totalBytesSoFar)
+          ProgressUI.requestCycle(localFile,
+                                  bytesTransferred,
+                                  index,
+                                  totalBytesSoFar)
       }
     }
 

--- a/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
+++ b/uishell/src/main/scala/net/kemitix/thorp/uishell/UIShell.scala
@@ -55,7 +55,8 @@ object UIShell {
         case StorageEvent.DeleteEvent(remoteKey) =>
           Console.putMessageLnB(DeleteComplete(remoteKey), batchMode)
         case StorageEvent.ErrorEvent(action, remoteKey, e) =>
-          Console.putMessageLnB(ErrorQueueEventOccurred(action, e), batchMode)
+          ProgressUI.finishedUploading(remoteKey) *>
+            Console.putMessageLnB(ErrorQueueEventOccurred(action, e), batchMode)
         case StorageEvent.ShutdownEvent() => UIO.unit
       }
     } yield ()


### PR DESCRIPTION
When uploading a file, the following error can occur:
```
ERROR: Upload ...: Unable to complete multi-part upload. Individual part upload failed : Unable to execute HTTP request: Connection reset
```
The `UIRequestCycle` is not notified that this upload has failed, so continues to show it as an upload still 'in-progress',
